### PR TITLE
Tests on localhost

### DIFF
--- a/gridftp/control/source/globus_ftp_control.h
+++ b/gridftp/control/source/globus_ftp_control.h
@@ -1422,6 +1422,14 @@ globus_ftp_control_server_listen(
     void *					callback_arg);
 
 globus_result_t
+globus_ftp_control_server_listen_ex(
+    globus_ftp_control_server_t *		handle,
+    globus_io_attr_t *				attr,
+    unsigned short *				port,
+    globus_ftp_control_server_callback_t	callback,
+    void *					callback_arg);
+
+globus_result_t
 globus_ftp_control_server_stop(
     globus_ftp_control_server_t *		listener,
     globus_ftp_control_server_callback_t	callback,

--- a/gridftp/control/source/globus_ftp_control_server.c
+++ b/gridftp/control/source/globus_ftp_control_server.c
@@ -279,9 +279,58 @@ globus_ftp_control_server_listen(
     globus_ftp_control_server_callback_t        callback,
     void *                                      callback_arg)
 {
+    globus_io_attr_t                            attr;
+    globus_io_tcpattr_init(&attr);
+    globus_ftp_control_server_listen_ex(
+        server_handle,
+        &attr,
+        port,
+        callback,
+        callback_arg
+    );
+}
+
+/**
+ * @brief Listen on for FTP Client Connections
+ * @ingroup globus_ftp_control_server
+ * @details
+ * This function starts the listening on *port for connections
+ * from ftp clients.  When a connection request is made callback is
+ * called and passed callback_arg.  Upon return from this function
+ * the server_handle structure is initialized.
+ *
+ * This is an extendend version of globus_ftp_control_server_listen()
+ * that provides additional control over the listening socket.
+ *
+ *  @param server_handle
+ *         A pointer to a initialized server handle.
+ *  @param attr
+ *         A pointer to a globus_io_attr_t providing additional attributes
+ *         for the listening socket.
+ *  @param port
+ *         A pointer to the port to listen on.  If the initial value
+ *         is zero it will be set to the default value.
+ *  @param callback
+ *         The callback function called when connection requests
+ *         are made.
+ *  @param callback_arg
+ *         The user argument passed to the callback function when 
+ *         connection requests are made.
+ *
+ *  @note I'm not providing any mechanism for making sure that this
+ *        function is only called once. Is this needed?
+ */
+
+globus_result_t
+globus_ftp_control_server_listen_ex(
+    globus_ftp_control_server_t *               server_handle,
+    globus_io_attr_t *                          attr,
+    unsigned short *                            port,
+    globus_ftp_control_server_callback_t        callback,
+    void *                                      callback_arg)
+{
     globus_result_t                             rc;
     int                                         backlog;
-    globus_io_attr_t                            attr;
 
     if(server_handle == GLOBUS_NULL)
     {
@@ -336,14 +385,12 @@ globus_ftp_control_server_listen(
 
     backlog=-1;
     
-    globus_io_tcpattr_init(&attr);
-    globus_io_attr_set_socket_oobinline(&attr, GLOBUS_TRUE);
-    globus_io_attr_set_tcp_nodelay(&attr, 
-                                   GLOBUS_TRUE);
+    globus_io_attr_set_socket_oobinline(attr, GLOBUS_TRUE);
+    globus_io_attr_set_tcp_nodelay(attr, GLOBUS_TRUE);
 
     rc=globus_io_tcp_create_listener(port,
                                      backlog,
-                                     &attr,
+                                     attr,
                                      &server_handle->io_handle);
     
 

--- a/gridftp/control/source/test/data_test.c
+++ b/gridftp/control/source/test/data_test.c
@@ -455,8 +455,11 @@ big_buffer_test(
 
     res = globus_i_ftp_control_data_cc_init(&pasv_handle);
     test_result(res, "pasv handle init", __LINE__);
+    globus_io_attr_set_tcp_interface(&pasv_handle.dc_handle.io_attr, "localhost");
+
     res = globus_i_ftp_control_data_cc_init(&port_handle);
     test_result(res, "port handle init", __LINE__);
+    globus_io_attr_set_tcp_interface(&port_handle.dc_handle.io_attr, "localhost");
 
     for(ctr = 0; ctr < TEST_ITERATIONS; ctr++)
     {
@@ -569,8 +572,11 @@ reuse_handles_test(
 
     res = globus_i_ftp_control_data_cc_init(&pasv_handle);
     test_result(res, "pasv handle init", __LINE__);
+    globus_io_attr_set_tcp_interface(&pasv_handle.dc_handle.io_attr, "localhost");
+
     res = globus_i_ftp_control_data_cc_init(&port_handle);
     test_result(res, "port handle init", __LINE__);
+    globus_io_attr_set_tcp_interface(&port_handle.dc_handle.io_attr, "localhost");
 
     if(!g_send_eof)
     {
@@ -757,8 +763,11 @@ cache_multiparallel_test(
 
     res = globus_i_ftp_control_data_cc_init(&pasv_handle);
     test_result(res, "pasv handle init", __LINE__);
+    globus_io_attr_set_tcp_interface(&pasv_handle.dc_handle.io_attr, "localhost");
+
     res = globus_i_ftp_control_data_cc_init(&port_handle);
     test_result(res, "port handle init", __LINE__);
+    globus_io_attr_set_tcp_interface(&port_handle.dc_handle.io_attr, "localhost");
 
     host_port.port = 0;
     globus_ftp_control_host_port_init(&host_port, "localhost", 0);
@@ -872,8 +881,11 @@ cache_test(
 
     res = globus_i_ftp_control_data_cc_init(&pasv_handle);
     test_result(res, "pasv handle init", __LINE__);
+    globus_io_attr_set_tcp_interface(&pasv_handle.dc_handle.io_attr, "localhost");
+
     res = globus_i_ftp_control_data_cc_init(&port_handle);
     test_result(res, "port handle init", __LINE__);
+    globus_io_attr_set_tcp_interface(&port_handle.dc_handle.io_attr, "localhost");
 
     host_port.port = 0;
     globus_ftp_control_host_port_init(&host_port, "localhost", 0);
@@ -1019,9 +1031,11 @@ transfer_test(
 
         res = globus_i_ftp_control_data_cc_init(pasv_handle);
         test_result(res, "pasv handle init", __LINE__);
+        globus_io_attr_set_tcp_interface(&pasv_handle->dc_handle.io_attr, "localhost");
      
         res = globus_i_ftp_control_data_cc_init(port_handle);
         test_result(res, "port handle init", __LINE__);
+        globus_io_attr_set_tcp_interface(&port_handle->dc_handle.io_attr, "localhost");
 
         /*
          * local_port/pasv()

--- a/gridftp/control/source/test/pipe_test.c
+++ b/gridftp/control/source/test/pipe_test.c
@@ -328,6 +328,7 @@ main(
     int                                         ctr;
     int                                         rc;
     globus_ftp_control_server_t                 server;
+    globus_io_attr_t                            attr;
 
     LTDL_SET_PRELOADED_SYMBOLS();
     printf("1..1\n");
@@ -359,8 +360,11 @@ main(
     ftp_test_monitor_init(&g_server_monitor);
 
     globus_ftp_control_server_handle_init(&server);
-    globus_ftp_control_server_listen(
+    globus_io_tcpattr_init(&attr);
+    globus_io_attr_set_tcp_interface(&attr, "localhost");
+    globus_ftp_control_server_listen_ex(
         &server, 
+        &attr,
         &g_bs_port,
         bullshit_server,
         GLOBUS_NULL);

--- a/gridftp/control/source/test/test_server.c
+++ b/gridftp/control/source/test/test_server.c
@@ -264,6 +264,7 @@ main(
     int                               rc;
     globus_result_t                   res;
     globus_ftp_control_server_t       server_handle;
+    globus_io_attr_t                  attr;
 
     LTDL_SET_PRELOADED_SYMBOLS();
 
@@ -278,8 +279,13 @@ main(
     res = globus_ftp_control_server_handle_init(&server_handle);
     error_msg(res, __LINE__);
 
-    res = globus_ftp_control_server_listen(
+    res = globus_io_tcpattr_init(&attr);
+    error_msg(res, __LINE__);
+    globus_io_attr_set_tcp_interface(&attr, "localhost");
+
+    res = globus_ftp_control_server_listen_ex(
               &server_handle,
+              &attr,
               &port,
               gpftpd_listen_callback,
               NULL);

--- a/io/compat/test/globus-io-tcp-test.pl
+++ b/io/compat/test/globus-io-tcp-test.pl
@@ -96,7 +96,7 @@ sub basic_func
        $ENV{X509_USER_PROXY} = "/bogus";
    }
    
-   my $command = "$valgrind $server_prog $server_args |";
+   my $command = "$valgrind $server_prog -I localhost $server_args |";
    #print "Running server: $command\n";
    $server_pid = open(SERVER, $command);
 

--- a/io/compat/test/globus_io_authorization_test.c
+++ b/io/compat/test/globus_io_authorization_test.c
@@ -141,6 +141,19 @@ main(
 	goto no_authorization_mode;
     }
 
+    result = globus_io_attr_set_tcp_interface(
+	    &attr,
+	    "localhost");
+
+    if(result != GLOBUS_SUCCESS)
+    {
+	char *msg = globus_error_print_friendly(globus_error_peek(result));
+	globus_libc_fprintf(stderr, "# Could not set interface: %s\n", msg);
+	free(msg);
+
+	goto error_exit;
+    }
+
     result = globus_io_tcp_create_listener(
 	    &port,
 	    -1,

--- a/xio/src/test/globus_utp_main.c
+++ b/xio/src/test/globus_utp_main.c
@@ -206,9 +206,7 @@ int globus_utp_init(unsigned numTimers, int mode)
 #endif
 
 	if (globus_libc_gethostname(hostnameBuff, MAXHOSTNAMELEN)) {
-	    /* globus_utp_warn("globus_utp_init: gethostname() failed; system error is "
-		         "\"%s\"", sys_errlist[errno]); */
-		return 1;
+	    memset(hostnameBuff, '\0', MAXHOSTNAMELEN);
 	}
 	globus_utp_set_attribute("%s", "hostname", hostnameBuff);
 

--- a/xio/src/test/http_performance_common.c
+++ b/xio/src/test/http_performance_common.c
@@ -243,6 +243,15 @@ http_test_server_init(
     {
         goto destroy_attr_error;
     }
+    result = globus_xio_attr_cntl(
+        attr,
+        tcp_driver,
+        GLOBUS_XIO_TCP_SET_INTERFACE,
+        "localhost");
+    if (result != GLOBUS_SUCCESS)
+    {
+        goto destroy_attr_error;
+    }
 
     result = globus_xio_server_create(
         &server->server, 

--- a/xio/src/test/http_test_common.c
+++ b/xio/src/test/http_test_common.c
@@ -212,6 +212,16 @@ http_test_server_init(
         goto free_cond_error;
     }
 
+    result = globus_xio_attr_cntl(
+        attr,
+        tcp_driver,
+        GLOBUS_XIO_TCP_SET_INTERFACE,
+        "localhost");
+    if (result != GLOBUS_SUCCESS)
+    {
+        goto destroy_attr_error;
+    }
+
     /*
     result = globus_xio_attr_cntl(
         attr,

--- a/xio/src/test/http_timeout_test.c
+++ b/xio/src/test/http_timeout_test.c
@@ -309,6 +309,13 @@ main(
         }
     }
 
+    /* Set up server attributes */
+    globus_xio_attr_cntl(
+            server_timeout_info.attr,
+            globus_l_tcp_driver,
+            GLOBUS_XIO_TCP_SET_INTERFACE,
+            "localhost");
+
     /* create server */
     server_timeout_info.state = GLOBUS_XIO_OPERATION_TYPE_ACCEPT;
     server_timeout_info.handle = NULL;


### PR DESCRIPTION
Some of the tests in the test suite fails because they do not explicitly request that the localhost interface should be used. These commits try to fix some of these problems.

There are some additional problems not solved by there changes. For those I could not find a quick fix, so I disabled those tests for now until a better solution is found:

In globus-gram-protocol the following tests fail: allow-attach-test, delegation-test and io-test.
In globus-gram-client the following test fails: callback-contact-test

In addition - the testhnok and the testhnfail test in globus-common's globus_args_scan_test.c requires network access to run properly, and can therefore not be run in Fedora's koji. I commented out these too.
