### PR TITLE
Remove EPEL-only dependencies

### DIFF
--- a/myproxy/oauth/source/README.md
+++ b/myproxy/oauth/source/README.md
@@ -34,14 +34,12 @@ Prerequisite packages on Debian-based systems:
 * python-crypto >= 2.0 and python-m2crypto or python-crypto >= 2.2
 * python-openssl
 * python-openssl
-* python-httplib2
 
 If you want to use this with apache2 instead of the standalone server, you'll
 also need libapache2-mod-wsgi and the apache2 server with the ssl module
 enabled and the default-ssl site enabled.
 
 Prerequisite packages on RedHat-based systems
-* python-httplib2
 * pyOpenSSL
 * python-crypto
 

--- a/myproxy/oauth/source/myproxy-oauth-setup
+++ b/myproxy/oauth/source/myproxy-oauth-setup
@@ -51,24 +51,24 @@ def public_name():
     return value
 
 """
-Register Globus Online as an OAuth client with this MyProxy OAuth Delegation
+Register Globus as an OAuth client with this MyProxy OAuth Delegation
 service. The registration consists of two steps:
-1. Get an access token from Globus Online.
-2. Trigger Globus Online client registration with this service.
+1. Get an access token from Globus.
+2. Trigger Globus client registration with this service.
 """
 def configure(username=None, pwstdin=False, oauth_server=None, myproxy_server=None, nexus_server=None):
 
     if username is None:
         default_user = getpass.getuser()
-        print "Globus Online Username [%s]: " % (default_user),
+        print "Globus Username [%s]: " % (default_user),
         username = sys.stdin.readline().strip()
         if username == '':
             username = default_user
     if pwstdin:
-        print "Globus Online Password: ",
+        print "Globus Password: ",
         password = sys.stdin.readline().strip()
     else:
-        password = getpass.getpass("Globus Online Password: ")
+        password = getpass.getpass("Globus Password: ")
 
     default_hostname = public_name()
 
@@ -137,7 +137,7 @@ def configure(username=None, pwstdin=False, oauth_server=None, myproxy_server=No
 
 def get_access_token(username, password, server):
     """
-    Get an access token from Globus Online Nexus.
+    Get an access token from Globus Nexus.
     Returns: an access token
     """
 

--- a/myproxy/oauth/source/oauth2/__init__.py
+++ b/myproxy/oauth/source/oauth2/__init__.py
@@ -28,7 +28,6 @@ import random
 import urlparse
 import hmac
 import binascii
-import httplib2
 
 try:
     from urlparse import parse_qs, parse_qsl
@@ -522,69 +521,6 @@ class Request(dict):
         for k, v in parameters.iteritems():
             parameters[k] = urllib.unquote(v[0])
         return parameters
-
-
-class Client(httplib2.Http):
-    """OAuthClient is a worker to attempt to execute a request."""
-
-    def __init__(self, consumer, token=None, cache=None, timeout=None,
-        proxy_info=None):
-
-        if consumer is not None and not isinstance(consumer, Consumer):
-            raise ValueError("Invalid consumer.")
-
-        if token is not None and not isinstance(token, Token):
-            raise ValueError("Invalid token.")
-
-        self.consumer = consumer
-        self.token = token
-        self.method = SignatureMethod_HMAC_SHA1()
-
-        httplib2.Http.__init__(self, cache=cache, timeout=timeout, 
-            proxy_info=proxy_info)
-
-    def set_signature_method(self, method):
-        if not isinstance(method, SignatureMethod):
-            raise ValueError("Invalid signature method.")
-
-        self.method = method
-
-    def request(self, uri, method="GET", body=None, headers=None, 
-        redirections=httplib2.DEFAULT_MAX_REDIRECTS, connection_type=None):
-        DEFAULT_CONTENT_TYPE = 'application/x-www-form-urlencoded'
-
-        if not isinstance(headers, dict):
-            headers = {}
-
-        is_multipart = method == 'POST' and headers.get('Content-Type', 
-            DEFAULT_CONTENT_TYPE) != DEFAULT_CONTENT_TYPE
-
-        if body and method == "POST" and not is_multipart:
-            parameters = dict(parse_qsl(body))
-        else:
-            parameters = None
-
-        req = Request.from_consumer_and_token(self.consumer, 
-            token=self.token, http_method=method, http_url=uri, 
-            parameters=parameters)
-
-        req.sign_request(self.method, self.consumer, self.token)
-
-        if method == "POST":
-            headers['Content-Type'] = headers.get('Content-Type', 
-                DEFAULT_CONTENT_TYPE)
-            if is_multipart:
-                headers.update(req.to_header())
-            else:
-                body = req.to_postdata()
-        elif method == "GET":
-            uri = req.to_url()
-        else:
-            headers.update(req.to_header())
-
-        return httplib2.Http.request(self, uri, method=method, body=body, 
-            headers=headers, redirections=redirections, 
-            connection_type=connection_type)
 
 
 class Server(object):

--- a/myproxy/oauth/source/setup.py
+++ b/myproxy/oauth/source/setup.py
@@ -3,7 +3,7 @@
 from distutils.core import setup
 
 setup(name = 'myproxy_oauth',
-    version = '0.15',
+    version = '0.16',
     description = 'MyProxy OAuth Delegation Service',
     author = 'Globus Toolkit',
     author_email = 'support@globus.org',

--- a/myproxy/source/Makefile.am
+++ b/myproxy/source/Makefile.am
@@ -16,6 +16,7 @@ LibSources= \
 	getopt_long.c \
 	gsi_socket.c \
 	gsi_socket.h \
+	gsi_socket_priv.h \
 	gssapi.c \
 	myproxy.c \
 	myproxy.h \
@@ -59,7 +60,6 @@ LibSources= \
 	string_funcs.h \
 	verror.c \
 	verror.h \
-	vomsclient.c \
 	vomsclient.h \
 	voms_utils.c \
 	voms_utils.h \
@@ -95,7 +95,13 @@ ACLOCAL_AMFLAGS = -I m4
 AM_CPPFLAGS = $(GLOBUS_CFLAGS)
 LDADD = $(GLOBUS_LIBS)
 
-lib_LTLIBRARIES = libmyproxy$(_GLOBUS_FLAVOR_NAME).la
+lib_LTLIBRARIES = libmyproxy$(_GLOBUS_FLAVOR_NAME).la 
+
+if HAVE_VOMS
+lib_LTLIBRARIES += libmyproxy_voms$(_GLOBUS_FLAVOR_NAME).la
+else
+EXTRA_LTLIBRARIES = libmyproxy_voms$(_GLOBUS_FLAVOR_NAME).la
+endif
 
 libmyproxy___GLOBUS_FLAVOR_NAME__la_SOURCES = $(LibSources)
 
@@ -103,6 +109,11 @@ libmyproxy___GLOBUS_FLAVOR_NAME__la_LDFLAGS = $(GPT_LDFLAGS) \
 	-version-info ${MAJOR_VERSION}:${MINOR_VERSION}:${AGE_VERSION}
 
 libmyproxy___GLOBUS_FLAVOR_NAME__la_LIBADD = $(GLOBUS_LIBS)
+
+libmyproxy_voms___GLOBUS_FLAVOR_NAME__la_SOURCES = gsi_socket_voms.c vomsclient.c
+libmyproxy_voms___GLOBUS_FLAVOR_NAME__la_LDFLAGS = $(GPT_LDFLAGS) \
+	-avoid-version -no-undefined
+libmyproxy_voms___GLOBUS_FLAVOR_NAME__la_LIBADD = $(VOMS_LIBS) $(GLOBUS_LIBS)
 
 bin_PROGRAMS= \
 	myproxy-init \

--- a/myproxy/source/configure.ac
+++ b/myproxy/source/configure.ac
@@ -1,6 +1,6 @@
 dnl Process this file with autoconf to produce a configure script.
 
-AC_INIT([myproxy],[6.1.5])
+AC_INIT([myproxy],[6.1.6])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([foreign])
 LT_INIT([dlopen win32-dll])
@@ -329,14 +329,21 @@ AC_ARG_WITH(voms,
 		if test "x$withval" != "xno" ; then
 		   CPPFLAGS="-I${withval}/include -I${withval}/include/voms -I${withval}/include/glite/security/voms $CPPFLAGS"
 		   LDFLAGS="-L${withval}/lib -L${withval}/lib64 $LDFLAGS"
+		   SAVE_LIBS="$LIBS"
 		   AC_CHECK_HEADER(voms_apic.h)
 		   AC_CHECK_HEADER(newformat.h)
-           AC_SEARCH_LIBS(VOMS_Init, vomsapi vomsc vomsc_$GLOBUS_FLAVOR_NAME, ,
+                   AC_SEARCH_LIBS(VOMS_Init, vomsapi vomsc vomsc_$GLOBUS_FLAVOR_NAME, ,
 			     AC_MSG_ERROR([VOMS_Init not found in libvomsapi/libvomsc]) )
-           AC_DEFINE(HAVE_VOMS)
+                   VOMS_LIBS="$LIBS"
+                   LIBS="$SAVE_LIBS"
+                   AC_SUBST([VOMS_LIBS])
+                   HAVE_VOMS=1
+                   AC_DEFINE(HAVE_VOMS)
 		fi
 	]
 )
+
+AM_CONDITIONAL([HAVE_VOMS], [test x"$HAVE_VOMS" = x1])
 
 AC_CONFIG_FILES([
 	Makefile

--- a/myproxy/source/gsi_socket_priv.h
+++ b/myproxy/source/gsi_socket_priv.h
@@ -1,0 +1,27 @@
+#ifndef GSI_SOCKET_PRIV_H
+#define GSI_SOCKET_PRIV_H 1
+/*
+ * gsi_socket_priv.h
+ *
+ * See gsi_socket.h for documentation.
+ */
+
+struct _gsi_socket 
+{
+    int				sock;
+    int				allow_anonymous; /* Boolean */
+    /* All these variables together indicate the last error we saw */
+    char			*error_string;
+    int				error_number;
+    gss_ctx_id_t		gss_context;
+    OM_uint32			major_status;
+    OM_uint32			minor_status;
+    char			*peer_name;
+    int             limited_proxy; /* 1 if peer used a limited proxy */
+    int             max_token_len;
+    char            *certreq;   /* path to a PEM encoded cert req */
+};
+
+#define DEFAULT_SERVICE_NAME		"host"
+
+#endif /* GSI_SOCKET_PRIV_H */

--- a/myproxy/source/gsi_socket_voms.c
+++ b/myproxy/source/gsi_socket_voms.c
@@ -1,0 +1,157 @@
+/*
+ * gsi_socket_voms.c
+ *
+ * See gsi_socket.h for documentation.
+ */
+
+#include "myproxy_common.h"
+#include "gsi_socket_priv.h"
+
+static int
+add_fqan(char ***fqans, const char *fqan)
+{
+   int current_len;
+   char **new_fqans;
+
+   if (fqans==NULL) {
+      return GSI_SOCKET_ERROR;
+   }
+
+
+   current_len = 0;
+   if (*fqans != NULL) {
+      while ((*fqans)[current_len] != NULL)
+	 current_len++;
+   }
+
+   new_fqans = realloc(*fqans, (current_len + 2) * sizeof(*new_fqans));
+   if (new_fqans == NULL) {
+      return GSI_SOCKET_ERROR;
+   }
+
+   new_fqans[current_len] = strdup(fqan);
+   new_fqans[current_len+1] = NULL;
+   *fqans = new_fqans;
+
+   return 0;
+}
+
+static gss_OID_desc gss_ext_x509_cert_chain_oid_desc =
+     {11, "\x2b\x06\x01\x04\x01\x9b\x50\x01\x01\x01\x08"}; 
+static gss_OID_desc * gss_ext_x509_cert_chain_oid =
+                &gss_ext_x509_cert_chain_oid_desc;
+
+static int
+GSI_SOCKET_get_peer_cert_chain(GSI_SOCKET *self,
+                               X509 **cert,
+                               STACK_OF(X509) **cert_chain)
+{
+    OM_uint32 major_status = 0;
+    OM_uint32 minor_status = 0;
+    gss_buffer_set_t buffer_set = NULL;
+    int i;
+
+    *cert = NULL;
+    *cert_chain = NULL;
+
+    major_status = gss_inquire_sec_context_by_oid(&minor_status,
+                                                  self->gss_context,
+                                                  gss_ext_x509_cert_chain_oid,
+                                                  &buffer_set);
+    if (major_status != GSS_S_COMPLETE) {
+        GSI_SOCKET_set_error_string(self, "gsi_inquire_sec_context_by_oid() failed in GSI_SOCKET_get_peer_cert_chain()");
+        return GSI_SOCKET_ERROR;
+    }
+
+    *cert_chain = sk_X509_new_null();
+
+    for (i = 0; i < buffer_set->count; i++) {
+        const unsigned char *p;
+        X509 *c;
+                    
+        p = buffer_set->elements[i].value;
+        c = d2i_X509(NULL, &p, buffer_set->elements[i].length);
+
+        if (i == 0) {
+            *cert = c;
+        } else {
+            if (sk_X509_insert(*cert_chain,
+                               c, sk_X509_num(*cert_chain)) == SSL_ERROR) {
+                GSI_SOCKET_set_error_string(self, "sk_X509_insert() failed in GSI_SOCKET_get_peer_cert_chain()");
+                gss_release_buffer_set(&minor_status, &buffer_set);
+                return GSI_SOCKET_ERROR;
+            }
+        }
+    }
+
+    gss_release_buffer_set(&minor_status, &buffer_set);
+    return GSI_SOCKET_SUCCESS;
+}
+
+int
+GSI_SOCKET_get_peer_fqans(GSI_SOCKET *self, char ***fqans)
+{
+   char **local_fqans = NULL;
+   int ret;
+   struct vomsdata *voms_data = NULL;
+   struct voms **voms_cert  = NULL;
+   char **fqan = NULL;
+   int voms_err;
+   char *err_msg, *err_str;
+   X509 *cert = NULL;
+   STACK_OF(X509) *cert_chain = NULL;
+
+   voms_data = VOMS_Init(NULL, NULL);
+   if (voms_data == NULL) {
+      GSI_SOCKET_set_error_string(self,
+                    "Failed to read VOMS attributes, VOMS_Init() failed");
+      return GSI_SOCKET_ERROR;
+   }
+
+   if (GSI_SOCKET_get_peer_cert_chain(self,
+                                      &cert,
+                                      &cert_chain) != GSI_SOCKET_SUCCESS) {
+      GSI_SOCKET_set_error_string(self, "Failed to read VOMS attributes, GSI_SOCKET_get_peer_cert_chain( failed");
+      return GSI_SOCKET_ERROR;
+   }
+
+   ret = VOMS_Retrieve(cert,
+                       cert_chain,
+                       RECURSE_CHAIN, voms_data, &voms_err);
+   if (ret == 0) {
+      if (voms_err == VERR_NOEXT) {
+	 /* No VOMS extensions present, return silently */
+	 ret = 0;
+	 goto end;
+      } else {
+         err_msg = VOMS_ErrorMessage(voms_data, voms_err, NULL, 0);
+         err_str = (char *)malloc(strlen(err_msg)+50);
+         snprintf(err_str, strlen(err_msg)+50,
+                  "Failed to read VOMS attributes: %s", err_msg);
+         GSI_SOCKET_set_error_string(self, err_str);
+	 free(err_msg);
+     free(err_str);
+	 ret = GSI_SOCKET_ERROR;
+	 goto end;
+      }
+   }
+
+   for (voms_cert = voms_data->data; voms_cert && *voms_cert; voms_cert++) {
+      for (fqan = (*voms_cert)->fqan; fqan && *fqan; fqan++) {
+	 add_fqan(&local_fqans, *fqan);
+      }
+   }
+
+   *fqans = local_fqans;
+   ret = 0;
+
+end:
+   if (voms_data)
+      VOMS_Destroy(voms_data);
+   if (cert)
+       X509_free(cert);
+   if (cert_chain)
+       sk_X509_pop_free(cert_chain, X509_free);
+
+   return ret;
+}

--- a/myproxy/source/myproxy_server.c
+++ b/myproxy/source/myproxy_server.c
@@ -5,6 +5,7 @@
  */
 
 #include "myproxy_common.h"	/* all needed headers included here */
+#include <dlfcn.h>
 
 #ifndef MAXPATHLEN
 #define MAXPATHLEN 4096
@@ -13,6 +14,9 @@
 #ifndef MIN
 #define MIN(x,y) ((x) < (y) ? (x) : (y))
 #endif
+
+int have_voms = 0;
+void (*get_voms_proxy_impl)();
 
 static char usage[] = \
 "\n"\
@@ -184,6 +188,7 @@ main(int argc, char *argv[])
     socklen_t client_addr_len = sizeof(client_addr);
     sigset_t mysigset;
     struct pidfh *pfh = NULL;
+    void * voms_lib_handle;
 
     myproxy_socket_attrs_t         *socket_attrs;
     myproxy_server_context_t       *server_context;
@@ -195,6 +200,13 @@ main(int argc, char *argv[])
 		MYPROXY_VERSION_DATE, myproxy_version(0,0,0));
 	exit(1);
     }
+    voms_lib_handle = dlopen("libmyproxy_voms.so", RTLD_LAZY|RTLD_LOCAL);
+    if (voms_lib_handle != NULL)
+    {
+        have_voms = 1;
+        get_voms_proxy_impl = dlsym(voms_lib_handle, "get_voms_proxy");
+    }
+
 
     socket_attrs    = malloc(sizeof(*socket_attrs));
     memset(socket_attrs, 0, sizeof(*socket_attrs));
@@ -816,15 +828,14 @@ handle_client(myproxy_socket_attrs_t *attrs,
                 myproxy_log_verror(); verror_clear();
             }
         }
-#ifdef HAVE_VOMS
-        if (client_request->voname != NULL &&
+        if (have_voms != 0 && get_voms_proxy_impl != NULL &&
+            client_request->voname != NULL &&
 	    context->allow_voms_attribute_requests) {
-            get_voms_proxy(attrs, client_creds, client_request,
+            get_voms_proxy_impl(attrs, client_creds, client_request,
                            server_response, 
                            context);
         }
         else
-#endif
 	    get_proxy(attrs, client_creds, client_request, server_response,
 		      context->max_proxy_lifetime);
 	  }

--- a/myproxy/source/vomsclient.c
+++ b/myproxy/source/vomsclient.c
@@ -1,5 +1,3 @@
-#ifdef HAVE_VOMS
-
 #include "myproxy_common.h"
 
 void get_voms_proxy(myproxy_socket_attrs_t *attrs,
@@ -896,6 +894,3 @@ voms_init_delegation(myproxy_socket_attrs_t *attrs,
     }
     return 0;
 }
-
-
-#endif

--- a/packaging/debian/myproxy-oauth/debian/changelog.in
+++ b/packaging/debian/myproxy-oauth/debian/changelog.in
@@ -1,3 +1,9 @@
+myproxy-oauth (0.16-1+gt6.@distro@) @distro@; urgency=low
+
+  * Remove python-httplib2 dependency in unused code
+
+ -- Globus Toolkit <support@globus.org>  Wed, 05 Nov 2014 14:28:51 -0500
+
 myproxy-oauth (0.15-4+gt6.@distro@) @distro@; urgency=low
 
   * Add python build dependency

--- a/packaging/debian/myproxy-oauth/debian/control
+++ b/packaging/debian/myproxy-oauth/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.9.3
 
 Package: myproxy-oauth
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, python (>= 2.5), python-crypto (>=2.2) | python-m2crypto, python-crypto (>= 2.0), python-openssl, python-httplib2, libapache2-mod-wsgi, apache2
+Depends: ${shlibs:Depends}, ${misc:Depends}, python (>= 2.5), python-crypto (>=2.2) | python-m2crypto, python-crypto (>= 2.0), python-openssl, libapache2-mod-wsgi, apache2
 Description: myproxy-oauth
  The Globus Toolkit is an open source software toolkit used for building Grid
  systems and applications. It is being developed by the Globus Alliance and

--- a/packaging/fedora/myproxy-oauth.spec
+++ b/packaging/fedora/myproxy-oauth.spec
@@ -1,7 +1,7 @@
 Name:		myproxy-oauth
 %global _name %(tr - _ <<< %{name})
-Version:	0.15
-Release:	2%{?dist}
+Version:	0.16
+Release:	1%{?dist}
 Summary:	MyProxy OAuth Delegation Serice
 
 Group:		System Environment/Libraries
@@ -35,7 +35,6 @@ Requires:       python-json
 Requires:       python-hashlib
 Requires:       python-ssl
 %endif
-Requires:       python-httplib2
 %if %{rhel} < 7
 Requires:       python-sqlite2
 %endif
@@ -43,10 +42,8 @@ Requires:       python-sqlite2
 %if 0%{?suse_version} > 0
 Requires:       python-crypto
 Requires:       python-m2crypto
-Requires:       python-httplib2
 %else
 Requires:       python-crypto >= 2.2
-Requires:       python-httplib2
 %endif
 %endif
 %if 0%{?rhel} == 05
@@ -136,6 +133,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_sbindir}/myproxy-oauth-setup
 
 %changelog
+* Wed Nov 05 2014 Globus Toolkit <support@globus.org> - 0.16-1
+- Remove httplib2 dependent code which is not used
+
 * Mon Aug 04 2014 Globus Toolkit <support@globus.org> - 0.15-2
 - Fix error in scriptlet to create wsgi socket dir on SLES 11
 

--- a/packaging/fedora/myproxy.spec
+++ b/packaging/fedora/myproxy.spec
@@ -1,6 +1,6 @@
 %{!?_initddir: %global _initddir %{_initrddir}}
 Name:           myproxy
-Version:	6.1.5
+Version:	6.1.6
 Release:	1%{?dist}
 Summary:        Manage X.509 Public Key Infrastructure (PKI) security credentials
 
@@ -48,9 +48,6 @@ BuildRequires:      globus-gss-assist-devel >= 8
 
 Requires:      myproxy-libs = %{version}-%{release}
 Requires:      globus-proxy-utils >= 5
-%if 0%{?suse_version} == 0
-Requires:      voms-clients
-%endif
 %if %{?fedora}%{!?fedora:0} >= 19 || %{?rhel}%{!?rhel:0} >= 7
 BuildRequires:	automake >= 1.11
 BuildRequires:	autoconf >= 2.60
@@ -171,6 +168,24 @@ trusted CA certificates and Certificate Revocation Lists (CRLs).
 
 Package %{name}-doc contains the MyProxy documentation.
 
+
+%package voms
+Summary:       Manage X.509 Public Key Infrastructure (PKI) security credentials 
+Group:         System Environment/Daemons
+Obsoletes:     myproxy < 5.1-3
+%if 0%{?suse_version} == 0
+Requires:      voms-clients
+%endif
+
+%description voms
+MyProxy is open source software for managing X.509 Public Key Infrastructure 
+(PKI) security credentials (certificates and private keys). MyProxy 
+combines an online credential repository with an online certificate 
+authority to allow users to securely obtain credentials when and where needed.
+Users run myproxy-logon to authenticate and obtain credentials, including 
+trusted CA certificates and Certificate Revocation Lists (CRLs). 
+
+Package %{name}-libs contains runtime libs for MyProxy to use VOMS.
 
 %prep
 %setup -q -n myproxy-%{version}
@@ -509,6 +524,9 @@ fi
 %{_includedir}/globus/verror.h
 %{_libdir}/libmyproxy.so
 %{_libdir}/pkgconfig/myproxy.pc
+
+%files voms
+%{_libdir}/libmyproxy_voms.so
 
 %changelog
 * Mon Nov 03 2014 Globus Toolkit <support@globus.org> - 6.1.5-1


### PR DESCRIPTION
This commit changes myproxy so that the VOMS support is pulled into a separate shared object libmyproxy_voms.so. This can be packaged as a separate package on fedora/rhel so that the VOMS dependency from EPEL isn't required to install the RPM packages in the default case.
