### PR TITLE
Allow TLS in myproxy

### DIFF
--- a/myproxy/source/myproxy.c
+++ b/myproxy/source/myproxy.c
@@ -544,8 +544,9 @@ myproxy_bootstrap_trust(myproxy_socket_attrs_t *attrs)
     }
 
     /* get trust root(s) from the myproxy-server */
-    ctx = SSL_CTX_new(SSLv3_client_method());
-    SSL_CTX_set_options(ctx, SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS);
+    ctx = SSL_CTX_new(SSLv23_client_method());
+    SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv2 |
+			SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS);
 
     if (!(sbio = BIO_new_ssl_connect(ctx))) goto error;
     if ( (sockfd = get_connected_myproxy_host_socket(

--- a/myproxy/source/myproxy_ocsp.c
+++ b/myproxy/source/myproxy_ocsp.c
@@ -311,11 +311,12 @@ int myproxy_ocsp_verify(X509 *cert, X509 *issuer) {
     goto end;
   }
   X509_LOOKUP_add_dir(lookup, certdir, X509_FILETYPE_PEM);
-  ctx = SSL_CTX_new(SSLv3_client_method());
+  ctx = SSL_CTX_new(SSLv23_client_method());
   if (ctx == NULL) {
     result = MYPROXY_OCSPRESULT_ERROR_OUTOFMEMORY;
     goto end;
   }
+  SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv2);
   SSL_CTX_set_cert_store(ctx, store);
   SSL_CTX_set_verify(ctx,SSL_VERIFY_PEER,NULL);
 

--- a/myproxy/source/ssl_utils.c
+++ b/myproxy/source/ssl_utils.c
@@ -2146,12 +2146,13 @@ ssl_verify_gsi_chain(SSL_CREDENTIALS *chain)
    X509_LOOKUP_add_dir(lookup, certdir, X509_FILETYPE_PEM);
    X509_STORE_CTX_init(&csc, cert_store, chain->certificate, NULL);
    
-   sslContext = SSL_CTX_new(SSLv3_server_method());
+   sslContext = SSL_CTX_new(SSLv23_server_method());
    if (sslContext == NULL) {
       verror_put_string("Initializing SSL_CTX");
       ssl_error_to_verror();
       goto end;
    }
+   SSL_CTX_set_options(sslContext, SSL_OP_NO_SSLv2);
 
    SSL_CTX_set_purpose(sslContext, X509_PURPOSE_ANY);
 


### PR DESCRIPTION
This change makes the myproxy test suite succeed with debian's openssl 1.0.1j-1 which disables SSLv3 by default.
