### PR TITLE
Myproxy systemd fix

### DIFF
--- a/myproxy/source/systemd/myproxy-server.service
+++ b/myproxy/source/systemd/myproxy-server.service
@@ -2,7 +2,7 @@
 
 [Unit]
 Description=Server for X.509 Public Key Infrastructure (PKI) security credentials
-After=syslog.target auditd.service
+After=network.target auditd.service
 
 [Service]
 Type=forking

--- a/myproxy/source/systemd/myproxy-server.service
+++ b/myproxy/source/systemd/myproxy-server.service
@@ -3,6 +3,8 @@
 [Unit]
 Description=Server for X.509 Public Key Infrastructure (PKI) security credentials
 After=network.target auditd.service
+ConditionPathExists=/etc/grid-security/myproxy/hostcert.pem
+ConditionPathExists=/etc/grid-security/myproxy/hostkey.pem
 
 [Service]
 Type=forking


### PR DESCRIPTION
Fixes lintian warning:
https://lintian.debian.org/tags/systemd-service-file-refers-to-obsolete-target.html

Fixes installation problem on debian when the server tries to start without certificates present.
