### PR TITLE
Better fix for testing on localhost

### DIFF
--- a/gridftp/control/source/globus_ftp_control_server.c
+++ b/gridftp/control/source/globus_ftp_control_server.c
@@ -345,6 +345,16 @@ globus_ftp_control_server_listen_ex(
             );
     }
 
+    if(attr == GLOBUS_NULL)
+    {
+        return globus_error_put(
+            globus_error_construct_string(
+                GLOBUS_FTP_CONTROL_MODULE,
+                GLOBUS_NULL,
+                _FCSL("globus_ftp_control_server_listen: attr argument is NULL"))
+            );
+    }
+
     if(port == GLOBUS_NULL)
     {
         return globus_error_put(

--- a/gridftp/control/source/test/data_test.c
+++ b/gridftp/control/source/test/data_test.c
@@ -455,18 +455,14 @@ big_buffer_test(
 
     res = globus_i_ftp_control_data_cc_init(&pasv_handle);
     test_result(res, "pasv handle init", __LINE__);
-    globus_io_attr_set_tcp_interface(&pasv_handle.dc_handle.io_attr, "localhost");
 
     res = globus_i_ftp_control_data_cc_init(&port_handle);
     test_result(res, "port handle init", __LINE__);
-    globus_io_attr_set_tcp_interface(&port_handle.dc_handle.io_attr, "localhost");
 
     for(ctr = 0; ctr < TEST_ITERATIONS; ctr++)
     {
         done_monitor.done = GLOBUS_FALSE;
         done_monitor.count = 0;
-
-        memset(&host_port, '\0', sizeof(host_port));
 
         globus_ftp_control_host_port_init(&host_port, "localhost", 0);
         res = globus_ftp_control_local_pasv(&pasv_handle, &host_port);
@@ -572,11 +568,9 @@ reuse_handles_test(
 
     res = globus_i_ftp_control_data_cc_init(&pasv_handle);
     test_result(res, "pasv handle init", __LINE__);
-    globus_io_attr_set_tcp_interface(&pasv_handle.dc_handle.io_attr, "localhost");
 
     res = globus_i_ftp_control_data_cc_init(&port_handle);
     test_result(res, "port handle init", __LINE__);
-    globus_io_attr_set_tcp_interface(&port_handle.dc_handle.io_attr, "localhost");
 
     if(!g_send_eof)
     {
@@ -592,7 +586,6 @@ reuse_handles_test(
         done_monitor.done = GLOBUS_FALSE;
         done_monitor.count = 0;
 
-        memset(&host_port, '\0', sizeof(host_port));
         globus_ftp_control_host_port_init(&host_port, "localhost", 0);
         res = globus_ftp_control_local_pasv(&pasv_handle, &host_port);
         test_result(res, "local pasv", __LINE__);
@@ -763,13 +756,10 @@ cache_multiparallel_test(
 
     res = globus_i_ftp_control_data_cc_init(&pasv_handle);
     test_result(res, "pasv handle init", __LINE__);
-    globus_io_attr_set_tcp_interface(&pasv_handle.dc_handle.io_attr, "localhost");
 
     res = globus_i_ftp_control_data_cc_init(&port_handle);
     test_result(res, "port handle init", __LINE__);
-    globus_io_attr_set_tcp_interface(&port_handle.dc_handle.io_attr, "localhost");
 
-    host_port.port = 0;
     globus_ftp_control_host_port_init(&host_port, "localhost", 0);
     res = globus_ftp_control_local_pasv(&pasv_handle, &host_port);
     test_result(res, "local pasv", __LINE__);
@@ -881,13 +871,10 @@ cache_test(
 
     res = globus_i_ftp_control_data_cc_init(&pasv_handle);
     test_result(res, "pasv handle init", __LINE__);
-    globus_io_attr_set_tcp_interface(&pasv_handle.dc_handle.io_attr, "localhost");
 
     res = globus_i_ftp_control_data_cc_init(&port_handle);
     test_result(res, "port handle init", __LINE__);
-    globus_io_attr_set_tcp_interface(&port_handle.dc_handle.io_attr, "localhost");
 
-    host_port.port = 0;
     globus_ftp_control_host_port_init(&host_port, "localhost", 0);
     res = globus_ftp_control_local_pasv(&pasv_handle, &host_port);
     test_result(res, "local pasv", __LINE__);
@@ -1031,11 +1018,9 @@ transfer_test(
 
         res = globus_i_ftp_control_data_cc_init(pasv_handle);
         test_result(res, "pasv handle init", __LINE__);
-        globus_io_attr_set_tcp_interface(&pasv_handle->dc_handle.io_attr, "localhost");
      
         res = globus_i_ftp_control_data_cc_init(port_handle);
         test_result(res, "port handle init", __LINE__);
-        globus_io_attr_set_tcp_interface(&port_handle->dc_handle.io_attr, "localhost");
 
         /*
          * local_port/pasv()

--- a/gridftp/control/source/test/pipe_test.c
+++ b/gridftp/control/source/test/pipe_test.c
@@ -328,7 +328,6 @@ main(
     int                                         ctr;
     int                                         rc;
     globus_ftp_control_server_t                 server;
-    globus_io_attr_t                            attr;
 
     LTDL_SET_PRELOADED_SYMBOLS();
     printf("1..1\n");
@@ -360,11 +359,8 @@ main(
     ftp_test_monitor_init(&g_server_monitor);
 
     globus_ftp_control_server_handle_init(&server);
-    globus_io_tcpattr_init(&attr);
-    globus_io_attr_set_tcp_interface(&attr, "localhost");
-    globus_ftp_control_server_listen_ex(
+    globus_ftp_control_server_listen(
         &server, 
-        &attr,
         &g_bs_port,
         bullshit_server,
         GLOBUS_NULL);

--- a/gridftp/control/source/test/test_server.c
+++ b/gridftp/control/source/test/test_server.c
@@ -264,7 +264,6 @@ main(
     int                               rc;
     globus_result_t                   res;
     globus_ftp_control_server_t       server_handle;
-    globus_io_attr_t                  attr;
 
     LTDL_SET_PRELOADED_SYMBOLS();
 
@@ -279,13 +278,8 @@ main(
     res = globus_ftp_control_server_handle_init(&server_handle);
     error_msg(res, __LINE__);
 
-    res = globus_io_tcpattr_init(&attr);
-    error_msg(res, __LINE__);
-    globus_io_attr_set_tcp_interface(&attr, "localhost");
-
-    res = globus_ftp_control_server_listen_ex(
+    res = globus_ftp_control_server_listen(
               &server_handle,
-              &attr,
               &port,
               gpftpd_listen_callback,
               NULL);

--- a/io/compat/test/globus-io-tcp-test.pl
+++ b/io/compat/test/globus-io-tcp-test.pl
@@ -96,7 +96,7 @@ sub basic_func
        $ENV{X509_USER_PROXY} = "/bogus";
    }
    
-   my $command = "$valgrind $server_prog -I localhost $server_args |";
+   my $command = "$valgrind $server_prog $server_args |";
    #print "Running server: $command\n";
    $server_pid = open(SERVER, $command);
 

--- a/io/compat/test/globus_io_authorization_test.c
+++ b/io/compat/test/globus_io_authorization_test.c
@@ -141,19 +141,6 @@ main(
 	goto no_authorization_mode;
     }
 
-    result = globus_io_attr_set_tcp_interface(
-	    &attr,
-	    "localhost");
-
-    if(result != GLOBUS_SUCCESS)
-    {
-	char *msg = globus_error_print_friendly(globus_error_peek(result));
-	globus_libc_fprintf(stderr, "# Could not set interface: %s\n", msg);
-	free(msg);
-
-	goto error_exit;
-    }
-
     result = globus_io_tcp_create_listener(
 	    &port,
 	    -1,

--- a/packaging/debian/globus-ftp-control/debian/rules
+++ b/packaging/debian/globus-ftp-control/debian/rules
@@ -80,7 +80,7 @@ build-stamp: configure-stamp
 
 	$(MAKE)
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
-	$(MAKE) check
+	GLOBUS_HOSTNAME=localhost $(MAKE) check
 endif
 
 	touch $@

--- a/packaging/debian/globus-gram-client/debian/rules
+++ b/packaging/debian/globus-gram-client/debian/rules
@@ -73,7 +73,7 @@ build-stamp: configure-stamp
 	dh_testdir
 	$(MAKE)
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
-	$(MAKE) check
+	GLOBUS_HOSTNAME=localhost $(MAKE) check
 endif
 	touch $@
 

--- a/packaging/debian/globus-gram-protocol/debian/rules
+++ b/packaging/debian/globus-gram-protocol/debian/rules
@@ -82,7 +82,7 @@ build-stamp: configure-stamp
 	dh_testdir
 	$(MAKE)
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
-	$(MAKE) check
+	GLOBUS_HOSTNAME=localhost $(MAKE) check
 endif
 	touch $@
 

--- a/packaging/debian/globus-io/debian/rules
+++ b/packaging/debian/globus-io/debian/rules
@@ -81,7 +81,7 @@ build-stamp: configure-stamp
 
 	$(MAKE)
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
-	$(MAKE) check
+	GLOBUS_HOSTNAME=localhost $(MAKE) check
 endif
 
 	touch $@

--- a/packaging/debian/globus-xio/debian/rules
+++ b/packaging/debian/globus-xio/debian/rules
@@ -76,7 +76,7 @@ build-stamp: configure-stamp
 
 	$(MAKE)
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
-	$(MAKE) check
+	GLOBUS_HOSTNAME=localhost $(MAKE) check
 endif
 
 	touch $@

--- a/packaging/fedora/globus-ftp-control.spec
+++ b/packaging/fedora/globus-ftp-control.spec
@@ -109,7 +109,7 @@ make install DESTDIR=$RPM_BUILD_ROOT
 find $RPM_BUILD_ROOT%{_libdir} -name 'lib*.la' -exec rm -v '{}' \;
 
 %check
-make %{?_smp_mflags} check
+GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check
 
 %clean
 rm -rf $RPM_BUILD_ROOT

--- a/packaging/fedora/globus-gram-client.spec
+++ b/packaging/fedora/globus-gram-client.spec
@@ -114,7 +114,7 @@ make install DESTDIR=$RPM_BUILD_ROOT
 find $RPM_BUILD_ROOT%{_libdir} -name 'lib*.la' -exec rm -v '{}' \;
 
 %check
-make %{?_smp_mflags} check
+GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check
 
 %clean
 rm -rf $RPM_BUILD_ROOT

--- a/packaging/fedora/globus-gram-protocol.spec
+++ b/packaging/fedora/globus-gram-protocol.spec
@@ -121,7 +121,7 @@ chmod 644 $RPM_BUILD_ROOT%{_datadir}/globus/globus-gram-protocol-constants.sh
 find $RPM_BUILD_ROOT%{_libdir} -name 'lib*.la' -exec rm -v '{}' \;
 
 %check
-make %{?_smp_mflags} check
+GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check
 
 %clean
 rm -rf $RPM_BUILD_ROOT

--- a/packaging/fedora/globus-io.spec
+++ b/packaging/fedora/globus-io.spec
@@ -95,7 +95,7 @@ find $RPM_BUILD_ROOT%{_libdir} -name 'lib*.la' -exec rm -v '{}' \;
 rm -rvf $RPM_BUILD_ROOT%{_mandir}
 
 %check
-make %{?_smp_mflags} check
+GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check
 
 %clean
 rm -rf $RPM_BUILD_ROOT

--- a/packaging/fedora/globus-xio.spec
+++ b/packaging/fedora/globus-xio.spec
@@ -112,7 +112,7 @@ done
 
 
 %check
-make %{?_smp_mflags} check
+GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check
 
 %clean
 rm -rf $RPM_BUILD_ROOT

--- a/xio/src/test/globus_utp_main.c
+++ b/xio/src/test/globus_utp_main.c
@@ -206,7 +206,9 @@ int globus_utp_init(unsigned numTimers, int mode)
 #endif
 
 	if (globus_libc_gethostname(hostnameBuff, MAXHOSTNAMELEN)) {
-	    memset(hostnameBuff, '\0', MAXHOSTNAMELEN);
+	    /* globus_utp_warn("globus_utp_init: gethostname() failed; system error is "
+		         "\"%s\"", sys_errlist[errno]); */
+		return 1;
 	}
 	globus_utp_set_attribute("%s", "hostname", hostnameBuff);
 

--- a/xio/src/test/http_timeout_test.c
+++ b/xio/src/test/http_timeout_test.c
@@ -309,13 +309,6 @@ main(
         }
     }
 
-    /* Set up server attributes */
-    globus_xio_attr_cntl(
-            server_timeout_info.attr,
-            globus_l_tcp_driver,
-            GLOBUS_XIO_TCP_SET_INTERFACE,
-            "localhost");
-
     /* create server */
     server_timeout_info.state = GLOBUS_XIO_OPERATION_TYPE_ACCEPT;
     server_timeout_info.handle = NULL;


### PR DESCRIPTION
Some time ago I submitted pull requests to make some ot the tests work in koji by forcing the use of the localhost inteface. Some of these were accepted and some of them rejected with the suggestion of using the GLOBUS_HOSTNAME environment variable instead.

Since then a few of the accepted ones were reverted because they caused problems for the windows build. These now also build properly using the GLOBUS_HOSTNAME solution.

In order to be consistent I suggest to also revert the remaining ones and use GLOBUS_HOSTNAME also for them. This pull request implements this suggestion.
