### PR TITLE
Don't call SSLv3_method unless it is available

### DIFF
--- a/gsi/gssapi/source/configure.ac
+++ b/gsi/gssapi/source/configure.ac
@@ -66,6 +66,8 @@ AC_LINK_IFELSE(
     [ac_cv_can_link_with_openssl_internal_api=yes],
     [ac_cv_can_link_with_openssl_internal_api=no])
 AC_MSG_RESULT([$ac_cv_can_link_with_openssl_internal_api])
+
+AC_CHECK_FUNCS(SSLv3_method)
 LIBS="$SAVE_LIBS"
 
 if test "$ac_cv_can_link_with_openssl_internal_api" = yes; then


### PR DESCRIPTION
The new openssl version in Debian was compiled without support for SSL v3. The compilation of globus-gssapi-gsi fails with:

library/globus_i_gsi_gss_utils.c:471: undefined reference to `SSLv3_method'
