### PR TITLE
Add necessary dependencies for gsi-openssh package.

### DIFF
--- a/packaging/debian/gsi-openssh/debian/control
+++ b/packaging/debian/gsi-openssh/debian/control
@@ -10,7 +10,7 @@ Homepage: http://www.globus.org/
 Package: gsi-openssh
 Section: net
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: libglobus-gss-assist3, libglobus-usage0, ${shlibs:Depends}, ${misc:Depends}
 Description: GSI OpenSSH
  OpenSSH is a free version of SSH (Secure SHell), a program for logging
  into and executing commands on a remote machine. This package includes


### PR DESCRIPTION
Without these the gsisshd daemon will not start. These dependencies match the -dev packages in the build dependencies and should be Debian 7/8/9 compatible. You might consider a fuller examination of the Build-Depends to add more library dependencies for gsi-openssh.
