### PR TITLE
Move grid-proxy-destroy call to before starting personal gatekeeper

### DIFF
--- a/gram/jobmanager/source/test/gram-test-wrapper.in
+++ b/gram/jobmanager/source/test/gram-test-wrapper.in
@@ -48,6 +48,8 @@ if [ -n "$PERL5LIB" ]; then
     export PERL5LIB
 fi
 
+grid-proxy-destroy 2>/dev/null || true
+
 if [ -n "$CONTACT_STRING" ]; then
     echo "#   Using existing GRAM service at $CONTACT_STRING"
 else
@@ -69,8 +71,6 @@ else
     trap cleanup EXIT
     export CONTACT_STRING="$contact"
 fi
-
-grid-proxy-destroy 2>/dev/null || true 
 
 # Perl scripts pass through, otherwise run the program under valgrind
 # conditionally


### PR DESCRIPTION
If there is a proxy file around the first test fails. By moving the call to grid-proxy-destroy to before starting the personal gatekeeper, this is fixed.

(Only the first test fails because when the second test is run the grid-proxy-destroy from the first test has removed the proxy.)
