### PR TITLE
Setting sysconfdir to $prefix/etc/gsissh instead of the default

### DIFF
--- a/prep-gsissh
+++ b/prep-gsissh
@@ -62,7 +62,7 @@ if [ ! -f "${unpacked_file}" ] || \
     done
     cat <<-"EOF" >"${gsissh_sourcedir}/configure.gnu"
 	#! /bin/sh
-	"${0%.gnu}" "$@" --with-gsi
+	"${0%.gnu}" "$@" --with-gsi --sysconfdir="\${prefix}/etc/gsissh"
 	EOF
     chmod a+x "${gsissh_sourcedir}/configure.gnu"
     echo "${openssh_tarball}" > "${unpacked_file}"


### PR DESCRIPTION
$prefix/etc so GSI-OpenSSH when installed to a non-standard location can locate the config files.
