### PR TITLE
Updated version and patch generation steps for 7.1p2f.

### DIFF
--- a/packaging/fedora/gsi-openssh.spec
+++ b/packaging/fedora/gsi-openssh.spec
@@ -30,7 +30,7 @@
 %global nologin 1
 
 %global gsi_openssh_rel 1
-%global gsi_openssh_ver 7.1p2e
+%global gsi_openssh_ver 7.1p2f
 
 Summary: An implementation of the SSH protocol with GSI authentication
 Name: gsi-openssh
@@ -68,12 +68,12 @@ Patch1: https://github.com/globus/gsi-openssh/releases/download/%{version}/hpn-i
 ## cd ..
 ## git clone https://github.com/globus/gsi-openssh.git
 ## cd gsi-openssh
-## git checkout tags/7.1p2e
+## git checkout tags/7.1p2f
 ## git log `cat ../changelog_last_commit`^... > ChangeLog
 ## make -f Makefile.in MANFMT="/usr/bin/nroff -mandoc" SHELL=$SHELL distprep
 ## rm -fr .git
 ## cd ..
-## diff -Naur openssh-7.1p2 gsi-openssh > hpn_isshd-gsi.7.1p2e.patch
+## diff -Naur openssh-7.1p2 gsi-openssh > hpn_isshd-gsi.7.1p2f.patch
 Patch2: https://github.com/globus/gsi-openssh/releases/download/%{version}/hpn_isshd-gsi.%{version}.patch
 
 License: BSD


### PR DESCRIPTION
GSI-OpenSSH 7.1p2f fixes issues with gsissh not being able to locate sshd_config when GT source installer and binary tarball are used to install to a non-standard location.
