### PR TITLE
Restrict pidofproc to $PID_FILE so it doesn't consider the currently

### DIFF
--- a/packaging/debian/gsi-openssh/debian/gsi-openssh-server.init
+++ b/packaging/debian/gsi-openssh/debian/gsi-openssh-server.init
@@ -224,7 +224,7 @@ rh_status() {
 }
 
 rh_status_q() {
-	pidofproc "$SSHD" > /dev/null
+	pidofproc -p "$PID_FILE" "$SSHD" > /dev/null
 }
 
 case "$1" in


### PR DESCRIPTION
running gsissh session as the main gsisshd service. This should fix:

https://github.com/globus/globus-toolkit/issues/49
