### PR TITLE
Add support for adler32 checksum algorithm.

### DIFF
--- a/gridftp/server/src/Makefile.am
+++ b/gridftp/server/src/Makefile.am
@@ -53,10 +53,10 @@ libglobus_gridftp_server_la_SOURCES =   \
 	globus_i_gfs_control.h
 
 globus_gridftp_server_SOURCES = globus_gridftp_server.c
-globus_gridftp_server_LDADD = libglobus_gridftp_server.la $(MODULE_DLOPEN) $(PACKAGE_DEP_LIBS) -lltdl
+globus_gridftp_server_LDADD = libglobus_gridftp_server.la $(MODULE_DLOPEN) $(PACKAGE_DEP_LIBS) -lltdl -lz
 
 globus_gridftp_server_noinst_SOURCES = globus_gridftp_server.c
-globus_gridftp_server_noinst_LDADD = libglobus_gridftp_server.la $(MODULE_DLPREOPEN) $(PACKAGE_DEP_LIBS) -lltdl
+globus_gridftp_server_noinst_LDADD = libglobus_gridftp_server.la $(MODULE_DLPREOPEN) $(PACKAGE_DEP_LIBS) -lltdl -lz
 
 gfs_gfork_master_SOURCES = gfs_gfork_master.c
 gfs_gfork_master_LDADD = $(preload_links) $(PACKAGE_DEP_LIBS) -lltdl


### PR DESCRIPTION
Additionally, this fixes a long-term bug: Globus GridFTP would return
the MD5 checksum regardless of the algorithm requested.  Now, it will
return an error if an unsupported checksum is requested.

Based on experience in the WLCG community, the algorithm name was
made case-insensitive.

_NOTE_: This simply adds `-lz` to the linker flags.  There's probably a better
way to add zlib to the package dependencies, but I couldn't figure it out.
