### PR TITLE
Do not overwrite configuration flags

### DIFF
--- a/myproxy/source/configure.ac
+++ b/myproxy/source/configure.ac
@@ -179,22 +179,12 @@ PKG_CHECK_MODULES([GLOBUS], [$PACKAGE_DEPS], [], [AC_MSG_ERROR([GLOBUS_PKG_ERROR
 fi
 PKG_CHECK_MODULES([OPENSSL], [openssl], [], [
     PKG_CHECK_MODULES([OPENSSL], [openssl101e])])
-CPPFLAGS="$CFLAGS $OPENSSL_CFLAGS"
-LDFLAGS="$LIBS $OPENSSL_LIBS"
+CPPFLAGS="$OPENSSL_CFLAGS $CPPFLAGS"
+LIBS="$OPENSSL_LIBS $LIBS"
 
 AC_PATH_PROG([OPENSSL],[openssl])
 AM_CONDITIONAL([ENABLE_TESTS], [test "x$OPENSSL" != x])
 
-dnl
-dnl Check for libcrypto
-dnl
-AC_SEARCH_LIBS(ENGINE_init, crypto_$GLOBUS_FLAVOR_NAME crypto, ,
-			     AC_MSG_ERROR([ENGINE_init not found in libcrypto]) )
-dnl
-dnl Check for libssl
-dnl
-AC_SEARCH_LIBS(SSL_library_init, ssl_$GLOBUS_FLAVOR_NAME ssl, ,
-			     AC_MSG_ERROR([SSL_library_init not found in libssl]) )
 dnl
 dnl Check for globus_usage_stats_send
 dnl


### PR DESCRIPTION
The latest myproxy configure file overwrites the values of CPPFLAGS and LDFLAGS instead of extending the original values. This pull request addresses this issue. It also removes the now redundant searches for the ssl and crypto libraries since these are now found using pkgconfig.
