### PR TITLE
Fixed oid equality check.

### DIFF
--- a/gsi/gssapi/source/library/init_sec_context.c
+++ b/gsi/gssapi/source/library/init_sec_context.c
@@ -139,13 +139,13 @@ GSS_CALLCONV gss_init_sec_context(
             }
         }
 #       if OPENSSL_VERSION_NUMBER < 0x10100000L
-        else if (mech_type == (gss_OID) gss_mech_globus_gssapi_openssl)
+        else if (g_OID_equal(mech_type, (gss_OID) gss_mech_globus_gssapi_openssl))
         {
             actual_mech = (gss_OID) gss_mech_globus_gssapi_openssl;
         }
 #       endif
 #       if OPENSSL_VERSION_NUMBER < 0x10000100L
-        else if (mech_type == (gss_OID) gss_mech_globus_gssapi_openssl_micv2)
+        else if (g_OID_equal(mech_type, (gss_OID) gss_mech_globus_gssapi_openssl_micv2))
         {
             actual_mech = gss_mech_globus_gssapi_openssl_micv2;
         }


### PR DESCRIPTION
For the new_gss_oid branch. gsissh client fails without this fix.
