### PR TITLE
Made accept_sec_context take mech oid from cred. indicate_mechs will …

### DIFF
--- a/gsi/gssapi/source/library/accept_sec_context.c
+++ b/gsi/gssapi/source/library/accept_sec_context.c
@@ -116,14 +116,18 @@ GSS_CALLCONV gss_accept_sec_context(
             nreq_flags = *ret_flags;
         }
 
-        if (globus_i_backward_compatible_mic)
-        {
-            actual_mech = (gss_OID) gss_mech_globus_gssapi_openssl;
-        }
-        else
-        {
-            actual_mech = (gss_OID) gss_mech_globus_gssapi_openssl_micv2;
-        }
+        /* Use mech from cred */
+        actual_mech = acceptor_cred_handle->mech;
+
+        GLOBUS_I_GSI_GSSAPI_DEBUG_FPRINTF(
+            2, (globus_i_gsi_gssapi_debug_fstream, 
+                "accept_sec_context:OID from cred:%s\n",
+                (actual_mech == GSS_C_NO_OID)? "GSS_C_NO_OID":
+                ((g_OID_equal(actual_mech, (gss_OID) gss_mech_globus_gssapi_openssl))?
+                  "OLD MECH OID":
+                 ((g_OID_equal(actual_mech, (gss_OID) gss_mech_globus_gssapi_openssl_micv2))?
+                  "MICV2 MECH OID": "UNKNOWN MECH OID"))));
+
         major_status = globus_i_gsi_gss_create_and_fill_context(
             & local_minor_status,
             & context,

--- a/gsi/gssapi/source/library/accept_sec_context.c
+++ b/gsi/gssapi/source/library/accept_sec_context.c
@@ -116,8 +116,9 @@ GSS_CALLCONV gss_accept_sec_context(
             nreq_flags = *ret_flags;
         }
 
-        /* Use mech from cred */
-        actual_mech = acceptor_cred_handle->mech;
+        /* Use mech from cred if available */
+        if (acceptor_cred_handle != GSS_C_NO_CREDENTIAL)
+            actual_mech = acceptor_cred_handle->mech;
 
         GLOBUS_I_GSI_GSSAPI_DEBUG_FPRINTF(
             2, (globus_i_gsi_gssapi_debug_fstream, 

--- a/gsi/gssapi/source/library/acquire_cred.c
+++ b/gsi/gssapi/source/library/acquire_cred.c
@@ -164,15 +164,17 @@ GSS_CALLCONV gss_acquire_cred(
             goto error;
         }
 
-        if ((gss_test_oid_set_member(&minor_status, gss_mech_globus_gssapi_openssl_micv2,
+        if ((gss_test_oid_set_member(&local_minor_status,
+                         (const gss_OID) gss_mech_globus_gssapi_openssl_micv2,
                          desired_mechs, &present) == GSS_S_COMPLETE) && present)
         {
-            (*output_cred_handle_P)->mech = gss_mech_globus_gssapi_openssl_micv2;
+            (*output_cred_handle_P)->mech = (const gss_OID)gss_mech_globus_gssapi_openssl_micv2;
         }
-        else if ((gss_test_oid_set_member(&minor_status, gss_mech_globus_gssapi_openssl,
+        else if ((gss_test_oid_set_member(&local_minor_status,
+                         (const gss_OID) gss_mech_globus_gssapi_openssl,
                          desired_mechs, &present) == GSS_S_COMPLETE) && present)
         {
-            (*output_cred_handle_P)->mech = gss_mech_globus_gssapi_openssl;
+            (*output_cred_handle_P)->mech = (const gss_OID)gss_mech_globus_gssapi_openssl;
         }
         else
         {
@@ -184,10 +186,10 @@ GSS_CALLCONV gss_acquire_cred(
         }
     } else if (globus_i_backward_compatible_mic)
     {
-            (*output_cred_handle_P)->mech = gss_mech_globus_gssapi_openssl;
+            (*output_cred_handle_P)->mech = (const gss_OID)gss_mech_globus_gssapi_openssl;
     } else
     {
-            (*output_cred_handle_P)->mech = gss_mech_globus_gssapi_openssl_micv2;
+            (*output_cred_handle_P)->mech = (const gss_OID)gss_mech_globus_gssapi_openssl_micv2;
     }
 
     GLOBUS_I_GSI_GSSAPI_DEBUG_FPRINTF(

--- a/gsi/gssapi/source/library/acquire_cred.c
+++ b/gsi/gssapi/source/library/acquire_cred.c
@@ -105,19 +105,6 @@ GSS_CALLCONV gss_acquire_cred(
         globus_module_activate(GLOBUS_GSI_GSSAPI_MODULE);
     }
     globus_mutex_unlock(&globus_i_gssapi_activate_mutex);
-    
-    if (actual_mechs != NULL)
-    {
-        major_status = gss_indicate_mechs(&local_minor_status,
-                                          actual_mechs);
-        if (GSS_ERROR(major_status))
-        {
-            GLOBUS_GSI_GSSAPI_ERROR_CHAIN_RESULT(
-                minor_status, local_minor_status,
-                GLOBUS_GSI_GSSAPI_ERROR_BAD_MECH);
-            goto exit;
-        }
-    }
 
     if(desired_name_P)
     {
@@ -161,6 +148,75 @@ GSS_CALLCONV gss_acquire_cred(
     if(desired_name_string)
     {
         free(desired_name_string);
+    }
+
+    /* Use new mech OID if present */
+    if (desired_mechs != NULL)
+    {
+        int present = 0;
+
+        if (desired_mechs->count > 1)
+        {
+            major_status = GSS_S_FAILURE;
+            GLOBUS_GSI_GSSAPI_ERROR_CHAIN_RESULT(
+                minor_status, local_minor_status,
+                GLOBUS_GSI_GSSAPI_ERROR_BAD_MECH);
+            goto error;
+        }
+
+        if ((gss_test_oid_set_member(&minor_status, gss_mech_globus_gssapi_openssl_micv2,
+                         desired_mechs, &present) == GSS_S_COMPLETE) && present)
+        {
+            (*output_cred_handle_P)->mech = gss_mech_globus_gssapi_openssl_micv2;
+        }
+        else if ((gss_test_oid_set_member(&minor_status, gss_mech_globus_gssapi_openssl,
+                         desired_mechs, &present) == GSS_S_COMPLETE) && present)
+        {
+            (*output_cred_handle_P)->mech = gss_mech_globus_gssapi_openssl;
+        }
+        else
+        {
+            major_status = GSS_S_FAILURE;
+            GLOBUS_GSI_GSSAPI_ERROR_CHAIN_RESULT(
+                minor_status, local_minor_status,
+                GLOBUS_GSI_GSSAPI_ERROR_BAD_MECH);
+            goto error;
+        }
+    } else if (globus_i_backward_compatible_mic)
+    {
+            (*output_cred_handle_P)->mech = gss_mech_globus_gssapi_openssl;
+    } else
+    {
+            (*output_cred_handle_P)->mech = gss_mech_globus_gssapi_openssl_micv2;
+    }
+
+    GLOBUS_I_GSI_GSSAPI_DEBUG_FPRINTF(
+        2, (globus_i_gsi_gssapi_debug_fstream,
+            "acquire_cred: %s\n",
+            ((*output_cred_handle_P)->mech == GSS_C_NO_OID)? "NO MECH OID":
+            ((g_OID_equal((*output_cred_handle_P)->mech, (gss_OID) gss_mech_globus_gssapi_openssl))?
+              "OLD MECH OID":
+             ((g_OID_equal((*output_cred_handle_P)->mech, (gss_OID) gss_mech_globus_gssapi_openssl_micv2))?
+              "MICV2 MECH OID": "UNKNOWN MECH OID"))));
+    
+    if (actual_mechs != NULL)
+    {
+        if ((*output_cred_handle_P)->mech != GSS_C_NO_OID)
+        {
+            major_status = gss_create_empty_oid_set(&local_minor_status, actual_mechs);
+            if (major_status == GSS_S_COMPLETE)
+                major_status = gss_add_oid_set_member(&local_minor_status,
+                                  (*output_cred_handle_P)->mech, actual_mechs);
+        } else
+            major_status = gss_indicate_mechs(&local_minor_status,
+                                          actual_mechs);
+        if (GSS_ERROR(major_status))
+        {
+            GLOBUS_GSI_GSSAPI_ERROR_CHAIN_RESULT(
+                minor_status, local_minor_status,
+                GLOBUS_GSI_GSSAPI_ERROR_BAD_MECH);
+            goto error;
+        }
     }
 
     goto exit;

--- a/gsi/gssapi/source/library/get_mic.c
+++ b/gsi/gssapi/source/library/get_mic.c
@@ -148,6 +148,9 @@ GSS_CALLCONV gss_get_mic(
         #if OPENSSL_VERSION_NUMBER < 0x10100000L
         if (g_OID_equal(context->mech, gss_mech_globus_gssapi_openssl))
         {
+            GLOBUS_I_GSI_GSSAPI_DEBUG_FPRINTF(
+                2, (globus_i_gsi_gssapi_debug_fstream,
+                    "get_mic: OLD MIC\n"));
             mac_sec = context->gss_ssl->s3->write_mac_secret;
             seq = context->gss_ssl->s3->write_sequence;
         }
@@ -156,6 +159,9 @@ GSS_CALLCONV gss_get_mic(
         {
             #if OPENSSL_VERSION_NUMBER >= 0x10000100L
                 mac_sec = context->mac_key;
+                GLOBUS_I_GSI_GSSAPI_DEBUG_FPRINTF(
+                    2, (globus_i_gsi_gssapi_debug_fstream,
+                        "get_mic: MICv2\n"));
             #else
                 GLOBUS_GSI_GSSAPI_MALLOC_ERROR(minor_status);
                 major_status = GSS_S_FAILURE;

--- a/gsi/gssapi/source/library/globus_i_gsi_gss_utils.c
+++ b/gsi/gssapi/source/library/globus_i_gsi_gss_utils.c
@@ -281,15 +281,13 @@ globus_i_gsi_gss_create_and_fill_context(
     globus_mutex_init(&context->mutex, NULL);
 
     /* initialize the peer_cred_handle */
-    context->peer_cred_handle = malloc(sizeof(gss_cred_id_desc));
+    context->peer_cred_handle = calloc(1, sizeof(gss_cred_id_desc));
     if(context->peer_cred_handle == NULL)
     {
         GLOBUS_GSI_GSSAPI_MALLOC_ERROR(minor_status);
         major_status = GSS_S_FAILURE;
         goto free_context;
     }
-
-    memset(context->peer_cred_handle, 0, sizeof(gss_cred_id_desc));
     
     local_result = globus_gsi_cred_handle_init(
         &context->peer_cred_handle->cred_handle, NULL);
@@ -1371,7 +1369,7 @@ globus_i_gsi_gss_create_anonymous_cred(
 
     *output_cred_handle = GSS_C_NO_CREDENTIAL;
     
-    newcred = (gss_cred_id_desc*) malloc(sizeof(gss_cred_id_desc));
+    newcred = (gss_cred_id_desc*) calloc(1, sizeof(gss_cred_id_desc));
     
     if (newcred == NULL)
     {

--- a/gsi/gssapi/source/library/gssapi_openssl.h
+++ b/gsi/gssapi/source/library/gssapi_openssl.h
@@ -162,6 +162,7 @@ typedef struct gss_cred_id_desc_struct {
     gss_name_desc *                     globusid;
     gss_cred_usage_t                    cred_usage;
     SSL_CTX *                           ssl_context;
+    gss_OID                             mech;
 } gss_cred_id_desc;
 
 typedef struct gss_ctx_id_desc_struct{

--- a/gsi/gssapi/source/library/import_cred.c
+++ b/gsi/gssapi/source/library/import_cred.c
@@ -236,10 +236,10 @@ GSS_CALLCONV gss_import_cred(
 
     if(desired_mech != NULL)
     {
-        if (!g_OID_equal(desired_mech, gss_mech_globus_gssapi_openssl))
-            ((gss_cred_id_desc *) *output_cred_handle)->mech = gss_mech_globus_gssapi_openssl;
-        else if (!g_OID_equal(desired_mech, gss_mech_globus_gssapi_openssl_micv2))
-            ((gss_cred_id_desc *) *output_cred_handle)->mech = gss_mech_globus_gssapi_openssl_micv2;
+        if (g_OID_equal(desired_mech, gss_mech_globus_gssapi_openssl))
+            ((gss_cred_id_desc *) *output_cred_handle)->mech = (const gss_OID)gss_mech_globus_gssapi_openssl;
+        else if (g_OID_equal(desired_mech, gss_mech_globus_gssapi_openssl_micv2))
+            ((gss_cred_id_desc *) *output_cred_handle)->mech = (const gss_OID)gss_mech_globus_gssapi_openssl_micv2;
         else {
             GLOBUS_GSI_GSSAPI_ERROR_RESULT(
                 minor_status,

--- a/gsi/gssapi/source/library/import_cred.c
+++ b/gsi/gssapi/source/library/import_cred.c
@@ -121,19 +121,6 @@ GSS_CALLCONV gss_import_cred(
         major_status = GSS_S_FAILURE;
         goto exit;
     }
-
-    if(desired_mech != NULL
-        && (!g_OID_equal(desired_mech, gss_mech_globus_gssapi_openssl))
-        && (!g_OID_equal(desired_mech, gss_mech_globus_gssapi_openssl_micv2)))
-    {
-        GLOBUS_GSI_GSSAPI_ERROR_RESULT(
-            minor_status,
-            GLOBUS_GSI_GSSAPI_ERROR_BAD_MECH,
-            (_GGSL("The desired_mech: %s, is not supported"),
-             ((gss_OID_desc *)desired_mech)->elements));
-        major_status = GSS_S_BAD_MECH;
-        goto exit;
-    }
     
     if (import_buffer->length > 0)
     {
@@ -245,6 +232,23 @@ GSS_CALLCONV gss_import_cred(
             goto exit;
         }
         *time_rec = (OM_uint32) lifetime;
+    }
+
+    if(desired_mech != NULL)
+    {
+        if (!g_OID_equal(desired_mech, gss_mech_globus_gssapi_openssl))
+            ((gss_cred_id_desc *) *output_cred_handle)->mech = gss_mech_globus_gssapi_openssl;
+        else if (!g_OID_equal(desired_mech, gss_mech_globus_gssapi_openssl_micv2))
+            ((gss_cred_id_desc *) *output_cred_handle)->mech = gss_mech_globus_gssapi_openssl_micv2;
+        else {
+            GLOBUS_GSI_GSSAPI_ERROR_RESULT(
+                minor_status,
+                GLOBUS_GSI_GSSAPI_ERROR_BAD_MECH,
+                (_GGSL("The desired_mech: %s, is not supported"),
+                 ((gss_OID_desc *)desired_mech)->elements));
+            major_status = GSS_S_BAD_MECH;
+            goto exit;
+        }
     }
         
  exit:

--- a/gsi/gssapi/source/library/init_sec_context.c
+++ b/gsi/gssapi/source/library/init_sec_context.c
@@ -156,7 +156,7 @@ GSS_CALLCONV gss_init_sec_context(
 #       if OPENSSL_VERSION_NUMBER >= 0x10000100L
         else if (g_OID_equal(mech_type, (gss_OID) gss_mech_globus_gssapi_openssl_micv2))
         {
-            actual_mech = gss_mech_globus_gssapi_openssl_micv2;
+            actual_mech = (const gss_OID) gss_mech_globus_gssapi_openssl_micv2;
                 GLOBUS_I_GSI_GSSAPI_DEBUG_FPRINTF(
                     2, (globus_i_gsi_gssapi_debug_fstream, 
                         "init_sec_context: MICV2 MECH OID requested\n"));

--- a/gsi/gssapi/source/library/init_sec_context.c
+++ b/gsi/gssapi/source/library/init_sec_context.c
@@ -132,22 +132,34 @@ GSS_CALLCONV gss_init_sec_context(
             if (globus_i_backward_compatible_mic)
             {
                 actual_mech = (gss_OID) gss_mech_globus_gssapi_openssl;
+                GLOBUS_I_GSI_GSSAPI_DEBUG_FPRINTF(
+                    2, (globus_i_gsi_gssapi_debug_fstream, 
+                        "init_sec_context: no mech_type requested; using OLD MECH OID\n"));
             }
             else
             {
                 actual_mech = (gss_OID) gss_mech_globus_gssapi_openssl_micv2;
+                GLOBUS_I_GSI_GSSAPI_DEBUG_FPRINTF(
+                    2, (globus_i_gsi_gssapi_debug_fstream, 
+                        "init_sec_context: no mech_type requested; using MICV2 MECH OID\n"));
             }
         }
 #       if OPENSSL_VERSION_NUMBER < 0x10100000L
         else if (g_OID_equal(mech_type, (gss_OID) gss_mech_globus_gssapi_openssl))
         {
             actual_mech = (gss_OID) gss_mech_globus_gssapi_openssl;
+                GLOBUS_I_GSI_GSSAPI_DEBUG_FPRINTF(
+                    2, (globus_i_gsi_gssapi_debug_fstream, 
+                        "init_sec_context: OLD MECH OID requested\n"));
         }
 #       endif
 #       if OPENSSL_VERSION_NUMBER >= 0x10000100L
         else if (g_OID_equal(mech_type, (gss_OID) gss_mech_globus_gssapi_openssl_micv2))
         {
             actual_mech = gss_mech_globus_gssapi_openssl_micv2;
+                GLOBUS_I_GSI_GSSAPI_DEBUG_FPRINTF(
+                    2, (globus_i_gsi_gssapi_debug_fstream, 
+                        "init_sec_context: MICV2 MECH OID requested\n"));
         }
 #       endif
         else

--- a/gsi/gssapi/source/library/module.c
+++ b/gsi/gssapi/source/library/module.c
@@ -454,7 +454,7 @@ globus_l_gsi_gssapi_activate(void)
         {
             globus_i_accept_backward_compatible_mic = GLOBUS_FALSE;
         }
-    } else
+    } else {
         globus_i_backward_compatible_mic = GLOBUS_FALSE;
         globus_i_accept_backward_compatible_mic = GLOBUS_FALSE;
     }

--- a/gsi/gssapi/source/library/module.c
+++ b/gsi/gssapi/source/library/module.c
@@ -76,9 +76,9 @@ const char *                            globus_i_gsi_gssapi_cipher_list;
  */
 globus_bool_t                           globus_i_gsi_gssapi_server_cipher_order ;
 
-globus_bool_t                           globus_i_backward_compatible_mic;
+globus_bool_t                           globus_i_backward_compatible_mic = GLOBUS_TRUE;
 
-globus_bool_t                           globus_i_accept_backward_compatible_mic;
+globus_bool_t                           globus_i_accept_backward_compatible_mic = GLOBUS_TRUE;
 /**
  * Module descriptor static initializer.
  */
@@ -432,6 +432,7 @@ globus_l_gsi_gssapi_activate(void)
 
     if (OPENSSL_VERSION_NUMBER < 0x10100000L)
     {
+
         globus_i_backward_compatible_mic = GLOBUS_TRUE;
         globus_i_accept_backward_compatible_mic = GLOBUS_TRUE;
 
@@ -453,6 +454,9 @@ globus_l_gsi_gssapi_activate(void)
         {
             globus_i_accept_backward_compatible_mic = GLOBUS_FALSE;
         }
+    } else
+        globus_i_backward_compatible_mic = GLOBUS_FALSE;
+        globus_i_accept_backward_compatible_mic = GLOBUS_FALSE;
     }
 
     rc = globus_module_activate(GLOBUS_OPENSSL_MODULE);

--- a/gsi/gssapi/source/library/module.c
+++ b/gsi/gssapi/source/library/module.c
@@ -432,7 +432,6 @@ globus_l_gsi_gssapi_activate(void)
 
     if (OPENSSL_VERSION_NUMBER < 0x10100000L)
     {
-
         globus_i_backward_compatible_mic = GLOBUS_TRUE;
         globus_i_accept_backward_compatible_mic = GLOBUS_TRUE;
 

--- a/gsi/gssapi/source/library/oid_functions.c
+++ b/gsi/gssapi/source/library/oid_functions.c
@@ -297,6 +297,22 @@ GSS_CALLCONV gss_indicate_mechs(
         goto exit;
     }
 
+    /* module activation if not already done by calling
+     * globus_module_activate
+     */
+ 
+    globus_thread_once(
+        &once_control,
+        globus_l_gsi_gssapi_activate_once);
+
+    globus_mutex_lock(&globus_i_gssapi_activate_mutex);
+    if (!globus_i_gssapi_active)
+    {
+        globus_module_activate(GLOBUS_GSI_GSSAPI_MODULE);
+    }
+    globus_mutex_unlock(&globus_i_gssapi_activate_mutex);
+
+
     *minor_status = (OM_uint32) GLOBUS_SUCCESS;
     
     major_status = gss_create_empty_oid_set(&local_minor_status, 
@@ -308,19 +324,25 @@ GSS_CALLCONV gss_indicate_mechs(
             GLOBUS_GSI_GSSAPI_ERROR_BAD_MECH);
         goto exit;
     }
-    
-    major_status = gss_add_oid_set_member(
-        &local_minor_status, 
-        (const gss_OID) gss_mech_globus_gssapi_openssl,
-        &set);
-    if (GSS_ERROR(major_status))
-    {
-        GLOBUS_GSI_GSSAPI_ERROR_CHAIN_RESULT(
-            minor_status, local_minor_status,
-            GLOBUS_GSI_GSSAPI_ERROR_WITH_OID);
-        
-        gss_release_oid_set(&local_minor_status, &set);
-        goto exit;
+
+    if (globus_i_backward_compatible_mic) {
+        major_status = gss_add_oid_set_member(
+            &local_minor_status, 
+            (const gss_OID) gss_mech_globus_gssapi_openssl,
+            &set);
+        if (GSS_ERROR(major_status))
+        {
+            GLOBUS_GSI_GSSAPI_ERROR_CHAIN_RESULT(
+                minor_status, local_minor_status,
+                GLOBUS_GSI_GSSAPI_ERROR_WITH_OID);
+            
+            gss_release_oid_set(&local_minor_status, &set);
+            goto exit;
+        } else {
+            GLOBUS_I_GSI_GSSAPI_DEBUG_FPRINTF(
+                2, (globus_i_gsi_gssapi_debug_fstream,
+                    "indicate_mechs: adding OLD OID\n"));
+        }
     }
     
     major_status = gss_add_oid_set_member(

--- a/gsi/gssapi/source/library/verify_mic.c
+++ b/gsi/gssapi/source/library/verify_mic.c
@@ -255,6 +255,10 @@ globus_l_gss_verify_mic_old(
 
     if (hash != NULL)
     {
+        GLOBUS_I_GSI_GSSAPI_DEBUG_FPRINTF(
+                2, (globus_i_gsi_gssapi_debug_fstream,
+                "verify_mic: verifying OLD MIC\n"));
+
         #if OPENSSL_VERSION_NUMBER < 0x10100000L
         {
             mac_sec = context_handle->gss_ssl->s3->read_mac_secret;
@@ -404,6 +408,10 @@ globus_l_gss_verify_mic_new(
 
     if (hash != NULL)
     {
+        GLOBUS_I_GSI_GSSAPI_DEBUG_FPRINTF(
+                2, (globus_i_gsi_gssapi_debug_fstream,
+                "verify_mic: verifying MICv2\n"));
+
         #if OPENSSL_VERSION_NUMBER >= 0x10000100L
         {
             mac_sec = context_handle->mac_key;


### PR DESCRIPTION
…now include

the old oid only when globus_i_backward_compatible_mic is true. Initializing
globus_i_backward_compatible_mic  and globus_i_accept_backward_compatible_mic to
true at definition in case globus_l_gsi_gssapi_activate isn't invoked a priori.

These changes are required for GSI-OpenSSH to successfully negotiate and use the appropriate mechanism OID.