### PR TITLE
Fix segfault due to unset get_issuer

### DIFF
--- a/gsi/callback/source/library/globus_gsi_callback.c
+++ b/gsi/callback/source/library/globus_gsi_callback.c
@@ -1064,8 +1064,7 @@ globus_i_gsi_callback_check_revoked(
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
             get_issuer = x509_context->get_issuer;
 #else
-            get_issuer = X509_STORE_get_get_issuer(
-                    X509_STORE_CTX_get0_store(x509_context));
+            get_issuer = X509_STORE_CTX_get_get_issuer(x509_context);
 #endif
 
             /* verify the signature on this CRL */


### PR DESCRIPTION
The get_issuer member of the x509_context struct (a *X509_STORE_CTX) is set to the default (which is the function X509_STORE_CTX_get1_issuer), but the get_issuer member of the x509_context->ctx struct (a *X509_STORE) is not set, hence calling X509_STORE_get_get_issuer(X509_STORE_CTX_get0_store(x509_context)) gives a NULL pointer which is then dereferenced in line 1071. In any case it would be better to check for that and returning an error when needed.
The segfault can be seen in gsi/gssapi/source/test/gssapi_import_context_test.c, happening in the second gss_init_sec_context (line 113).