### PR TITLE
update instruction to use myproxy-oauth-setup for registration

### DIFF
--- a/myproxy/oauth/source/README.md
+++ b/myproxy/oauth/source/README.md
@@ -23,10 +23,10 @@ and displayed directly in a web browser. The templates are accessible at
 https://hostname/oauth/templates/, and the static files at
 https://hostname/oauth/static/.
 
-To use the service with Globus Online, Globus Online that acts here as an OAuth
-client has to be registered with the service first. To trigger the registration
-workflow, go to https://hostname/oauth/configure. A Globus Online user
-specified in the registration form will become an admin of the service.
+To use the service with Globus Online, Globus Online, that acts here as an OAuth
+client, has to be registered with the service first. To trigger the registration
+workflow, run `myproxy-oauth-setup` from the server cli. The Globus Online user
+specified in setup will become an admin of the service.
 
 Prerequisite packages on Debian-based systems:
 

--- a/myproxy/oauth/source/README.md
+++ b/myproxy/oauth/source/README.md
@@ -33,7 +33,6 @@ Prerequisite packages on Debian-based systems:
 * python >= 2.5
 * python-crypto >= 2.0 and python-m2crypto or python-crypto >= 2.2
 * python-openssl
-* python-openssl
 
 If you want to use this with apache2 instead of the standalone server, you'll
 also need libapache2-mod-wsgi and the apache2 server with the ssl module


### PR DESCRIPTION
Looking at `myproxyoauth/views.py` a route for `configure` does not exist. Accessing `https://myproxyserver.ccs.ornl.gov/oauth/configure` returns `404 Not Found`. Feel free to edit this change as you wish.