### PR TITLE
pkg-config file typos

### DIFF
--- a/gridftp/net_manager/xio_driver/globus-xio-net-manager-driver-uninstalled.pc.in
+++ b/gridftp/net_manager/xio_driver/globus-xio-net-manager-driver-uninstalled.pc.in
@@ -8,5 +8,5 @@ dlopen=-dlopen @abs_builddir@/libglobus_xio_net_manager_driver.la
 Name: globus-xio-net-manager-driver
 Description: Globus Toolkit - Globus XIO Net Manager Driver
 Version: @VERSION@
-Requires.private: @PACKAGE_DEPS@ globus-net-manager
+Requires.private: @PACKAGE_DEPS@, globus-net-manager
 Cflags: -I${abs_top_srcdir}

--- a/gridftp/net_manager/xio_driver/globus-xio-net-manager-driver.pc.in
+++ b/gridftp/net_manager/xio_driver/globus-xio-net-manager-driver.pc.in
@@ -6,6 +6,6 @@ includedir=@includedir@
 Name: globus-xio-net-manager-driver
 Description: Globus Toolkit - Globus XIO Net Manager Driver
 Version: @VERSION@
-Requires.private: @PACKAGE_DEPS@ globus-xio-net-manager
+Requires.private: @PACKAGE_DEPS@, globus-net-manager
 Libs: -L${libdir}
 Cflags: -I${includedir}

--- a/xio/drivers/pipe/source/globus-xio-pipe-driver-uninstalled.pc.in
+++ b/xio/drivers/pipe/source/globus-xio-pipe-driver-uninstalled.pc.in
@@ -11,4 +11,4 @@ Name: globus-xio-pipe-driver
 Description: Globus Toolkit - Globus Pipe Driver
 Version: @VERSION@
 Requires.private: @PACKAGE_DEPS@
-Cflags: -I${includedir} 
+Cflags: -I${abs_top_srcdir}

--- a/xio/drivers/pipe/source/globus-xio-pipe-driver.pc.in
+++ b/xio/drivers/pipe/source/globus-xio-pipe-driver.pc.in
@@ -7,4 +7,4 @@ Name: globus-xio-pipe-driver
 Description: Globus Toolkit - Globus Pipe Driver
 Version: @PACKAGE_VERSION@
 Requires.private: @PACKAGE_DEPS@
-Cflags: -I${includedir} 
+Cflags: -I${includedir}


### PR DESCRIPTION
$ pkg-config --libs --static globus-xio-net-manager-driver
Package globus-xio-net-manager was not found in the pkg-config search path.
Perhaps you should add the directory containing `globus-xio-net-manager.pc'
to the PKG_CONFIG_PATH environment variable
Package 'globus-xio-net-manager', required by 'globus-xio-net-manager-driver', not found

globus-xio-net-manager should be globus-net-manager - it is correct in the "uninstalled" pkg-config file.

globus-xio-pipe-driver-uninstalled.pc is the only "uninstalled" pkg-config file that says -I${includedir}.
