### PR TITLE
Adds an optional IPv6 address to EPSV response

### DIFF
--- a/gridftp/server-lib/src/globus_gridftp_server_control.c
+++ b/gridftp/server-lib/src/globus_gridftp_server_control.c
@@ -2938,6 +2938,7 @@ globus_gridftp_server_control_start(
         goto err;
     }
 
+    server_handle->epsv_ip = i_attr->epsv_ip;
     server_handle->security_type = i_attr->security;
     globus_xio_stack_destroy(xio_stack);
     server_handle->ref = 1;

--- a/gridftp/server-lib/src/globus_gridftp_server_control.h
+++ b/gridftp/server-lib/src/globus_gridftp_server_control.h
@@ -553,6 +553,11 @@ globus_gridftp_server_control_attr_set_idle_time(
     int                                     idle_timeout,
     int                                     preauth_timeout);
 
+globus_result_t
+globus_gridftp_server_control_attr_set_epsv_ip(
+    globus_gridftp_server_control_attr_t    in_attr,
+    globus_bool_t                           epsv_ip);
+
 /*
  *  if module name is NULL then it is the default handler
  */

--- a/gridftp/server-lib/src/globus_gridftp_server_control_attr.c
+++ b/gridftp/server-lib/src/globus_gridftp_server_control_attr.c
@@ -639,6 +639,25 @@ globus_gridftp_server_control_attr_set_idle_time(
 }
 
 globus_result_t
+globus_gridftp_server_control_attr_set_epsv_ip(
+    globus_gridftp_server_control_attr_t    in_attr,
+    globus_bool_t                           epsv_ip)
+{
+    globus_i_gsc_attr_t *                   attr;
+    GlobusGridFTPServerName(globus_gridftp_server_control_attr_set_epsv_ip);
+
+    if(in_attr == NULL)
+    {
+        return GlobusGridFTPServerErrorParameter("server_attr");
+    }
+    attr = (globus_i_gsc_attr_t *) in_attr;
+
+    attr->epsv_ip = epsv_ip;
+
+    return GLOBUS_SUCCESS;
+}
+
+globus_result_t
 globus_gridftp_server_control_attr_set_message(
     globus_gridftp_server_control_attr_t    in_attr,
     char *                                  message)

--- a/gridftp/server-lib/src/globus_gridftp_server_control_commands.c
+++ b/gridftp/server-lib/src/globus_gridftp_server_control_commands.c
@@ -2062,7 +2062,7 @@ globus_l_gsc_cmd_pasv_cb(
                 goto err;
             }
             
-            if(0)
+            if(op->server_handle->epsv_ip)
             {
                 msg = globus_common_create_string(
                     "%d Entering Passive Mode (|%d|%s|%d|)\r\n",

--- a/gridftp/server-lib/src/globus_gridftp_server_control_commands.c
+++ b/gridftp/server-lib/src/globus_gridftp_server_control_commands.c
@@ -2042,10 +2042,15 @@ globus_l_gsc_cmd_pasv_cb(
             }
             
             h = host;
-            if(*cs[0] == '[')
+            if(*host == '[')
             {
                 h++;
                 *(p - 1) = 0;
+                if (strncmp(h, "::ffff:", 7) == 0) /* IPv4 mapped address */
+                {
+                    h += 7;
+                    *host = ' ';
+                }
             }
             else
             {
@@ -2067,7 +2072,7 @@ globus_l_gsc_cmd_pasv_cb(
                 msg = globus_common_create_string(
                     "%d Entering Passive Mode (|%d|%s|%d|)\r\n",
                         wrapper->reply_code,
-                        *cs[0] == '[' ? 2 : 1,
+                        *host == '[' ? 2 : 1,
                         h,
                         (int) port);
             }

--- a/gridftp/server-lib/src/globus_i_gridftp_server_control.h
+++ b/gridftp/server-lib/src/globus_i_gridftp_server_control.h
@@ -335,6 +335,7 @@ typedef struct globus_i_gsc_attr_s
     char *                                  post_auth_banner;
     char *                                  pre_auth_banner;
     globus_gridftp_server_control_security_type_t   security;
+    globus_bool_t                           epsv_ip;
 
     int                                     idle_timeout;
     int                                     preauth_timeout;
@@ -470,6 +471,7 @@ typedef struct globus_i_gsc_server_handle_s
     int                                 preauth_timeout;
     
     globus_i_gsc_cmd_wrapper_t *        pasv_info;
+    globus_bool_t                       epsv_ip;
 
     globus_bool_t                       q_backup;
     int                                 max_q_len;

--- a/gridftp/server/src/globus_i_gfs_config.c
+++ b/gridftp/server/src/globus_i_gfs_config.c
@@ -430,6 +430,8 @@ static const globus_l_gfs_config_option_t option_list[] =
     "This, along with -data-interface, can be used to enable operation behind "
     "a firewall and/or when NAT is involved. "
     "This is the same as setting the environment variable GLOBUS_TCP_PORT_RANGE.", NULL, NULL, GLOBUS_FALSE, NULL},
+ {"epsv_ip", "epsv_ip", NULL, "epsv-ip", NULL, GLOBUS_L_GFS_CONFIG_BOOL, GLOBUS_FALSE, NULL,
+    "Adds an IPv6 address to EPSV response. Breaks RFC 2428, but allows redirection to work with IPv6.", NULL, NULL, GLOBUS_FALSE, NULL},
 {NULL, "User Messages", NULL, NULL, NULL, 0, 0, NULL, NULL, NULL, NULL,GLOBUS_FALSE, NULL},
  {"banner", "banner", NULL, "banner", NULL, GLOBUS_L_GFS_CONFIG_STRING, 0, NULL,
     "Message to display to the client before authentication.", NULL, NULL,GLOBUS_TRUE, NULL},

--- a/gridftp/server/src/globus_i_gfs_control.c
+++ b/gridftp/server/src/globus_i_gfs_control.c
@@ -3664,6 +3664,13 @@ globus_i_gfs_control_start(
         goto error_attr_setup;
     }
 
+    result = globus_gridftp_server_control_attr_set_epsv_ip(
+        attr, globus_i_gfs_config_bool("epsv_ip"));
+    if(result != GLOBUS_SUCCESS)
+    {
+        goto error_attr_setup;
+    }
+
     idle_timeout = globus_i_gfs_config_int("control_idle_timeout");
     preauth_timeout = globus_i_gfs_config_int("control_preauth_timeout");
     


### PR DESCRIPTION
This pull request is forwarded from the developers of DPM (disk pool manager). Their description of the proposed change follows. The pull request is created using the patches mentioned below. The original author of the text below is @andrea-manzi.

"While investigating an issue affecting one DPM in production we have realized that a commit in globus some time ago has broken the gridftp redirection implementation when using IPv6.

We don't know exactly when this was pushed to EPEL, but we are seeing this problem only now as sites are starting to use IPv6 and enabling gridftp redirection to go SRM free.

In this commit https://github.com/globus/globus-toolkit/commit/36187a296f9b55d7e774b173c299289f6cfc1146 they removed the IP field from the response to a EPSV command, thus breaking the redirection code.

Andrey prepared 2 patches, one for globus-gridftp-server:

https://cern.ch/kiryanov/gridftp_server_epsv_ip.patch

and one for globus-gridftp-server-control:

https://cern.ch/kiryanov/gridftp_server_control_epsv_ip.patch

adding a boolean 'epsv_ip' option to Gridftp server (both gridftp.conf and command line), which being set to 1 enables the old-style EPSV response with IPv6 address.

Do you think you can include these patches in EPEL or better see if we can include them upstream?

We are trying to understand if it's possible to fix this issue in other ways but this one seems to be the only feasible."
