### PR TITLE
Glib link

### DIFF
--- a/xio/drivers/udt/source/Makefile.am
+++ b/xio/drivers/udt/source/Makefile.am
@@ -7,10 +7,10 @@ doc_DATA = GLOBUS_LICENSE
 lib_LTLIBRARIES = libglobus_xio_udt_driver.la
 pkgconfig_DATA = globus-xio-udt-driver.pc
 
-AM_CPPFLAGS = $(PACKAGE_DEP_CFLAGS) $(UDT_CPPFLAGS) $(NICE_CFLAGS) $(GLIB_CFLAGS)
+AM_CPPFLAGS = $(PACKAGE_DEP_CFLAGS) $(UDT_CPPFLAGS) $(NICE_CFLAGS) $(GLIB2_CFLAGS)
 
 libglobus_xio_udt_driver_la_LIBADD = \
-        $(PACKAGE_DEP_LIBS) $(UDT_LDFLAGS) $(NICE_LIBS) $(GLIB_LIBS) $(LIBFFI_LIBS) -lstdc++ 
+        $(PACKAGE_DEP_LIBS) $(UDT_LDFLAGS) $(NICE_LIBS) $(GLIB2_LIBS) $(LIBFFI_LIBS) -lstdc++
 libglobus_xio_udt_driver_la_SOURCES = \
         globus_xio_udt_ref.cpp  \
         globus_xio_udt_ref.h  \

--- a/xio/drivers/udt/source/configure.ac
+++ b/xio/drivers/udt/source/configure.ac
@@ -123,14 +123,14 @@ if test X"$use_included_nice" = X1; then
     NICE_CFLAGS="\$\$(env PKG_CONFIG_PATH=\"\$(UDT_DRIVER_PKG_CONFIG_PATH)\" ${PKG_CONFIG} --define-variable=prefix=\"\$(abs_builddir)/libnice\$(prefix)\" --cflags nice)"
     NICE_LIBS="\$\$(env PKG_CONFIG_PATH=\"\$(UDT_DRIVER_PKG_CONFIG_PATH)\" ${PKG_CONFIG} --define-variable=prefix=\"\$(abs_builddir)/libnice\$(prefix)\" --libs nice)"
     NICE_VERSION_AT_LEAST_0_1_2=1
-
-    if test X"$use_included_glib2" = "X"; then
-        PKG_CHECK_MODULES([GLIB2], [glib-2.0 >= 2.20 gobject-2.0 >= 2.20 gthread-2.0 >= 2.20], [], [use_included_glib2=1])
-    fi
 fi
 
 if test $NICE_VERSION_AT_LEAST_0_1_2 = 1; then
     AC_DEFINE([NICE_VERSION_AT_LEAST_0_1_2], [1], [Define if libnice is at least 0.1.2])
+fi
+
+if test X"$use_included_glib2" = "X"; then
+    PKG_CHECK_MODULES([GLIB2], [glib-2.0 >= 2.20 gobject-2.0 >= 2.20 gthread-2.0 >= 2.20], [], [use_included_glib2=1])
 fi
 
 if test X"$use_included_glib2" = X1; then

--- a/xio/drivers/udt/source/configure.ac
+++ b/xio/drivers/udt/source/configure.ac
@@ -145,11 +145,6 @@ if test X"$use_included_glib2" = X1; then
     if test X"$GETTEXT" = X""; then
         use_included_gettext=1
     fi
-    AC_DEFINE([HAVE_GIO_GIO_H], [1], [Define to 1 if you have gio/gio.h])
-else
-    PKG_CHECK_MODULES([GIO], [gio-2.0 >= 2.30],,[:])
-    CPPFLAGS="$CPPFLAGS $GIO_CFLAGS"
-    AC_CHECK_HEADER([gio/gio.h], [AC_DEFINE([HAVE_GIO_GIO_H], [1], [Define to 1 if you have gio/gio.h])])
 fi
 
 if test X"$use_included_libffi" = X1; then

--- a/xio/drivers/udt/source/ice.c
+++ b/xio/drivers/udt/source/ice.c
@@ -29,6 +29,9 @@
 
 #define GLIB_VERSION_MIN_REQUIRED GLIB_VERSION_2_30
 #include <glib.h>
+#if NICE_VERSION_AT_LEAST_0_1_2
+#include <gio/gio.h>
+#endif
 
 #include "ice.h"
 

--- a/xio/drivers/udt/source/ice.h
+++ b/xio/drivers/udt/source/ice.h
@@ -29,9 +29,7 @@
 #endif
 
 #include <nice/agent.h>
-#if HAVE_GIO_GIO_H
-#include <gio/gio.h>
-#endif
+#include <glib.h>
 
 #define ICE_SUCCESS 0
 #define ICE_FAILURE -1


### PR DESCRIPTION
```
.libs/ice.o: In function `ice_lib_init':
..../globus_xio_udt_driver-1.27/ice.c:76: undefined reference to `g_thread_init'
collect2: error: ld returned 1 exit status
Makefile:557: recipe for target 'libglobus_xio_udt_driver.la' failed
make[1]: *** [libglobus_xio_udt_driver.la] Error 1
make[1]: Leaving directory '..../globus_xio_udt_driver-1.27'
Makefile:695: recipe for target 'all-recursive' failed
make: *** [all-recursive] Error 1
```
