### PR TITLE
Adapt to Perl 5.26 - POSIX::tmpnam() no longer available

### DIFF
--- a/gram/client_tools/test/globus-gram-client-tools-local-test.pl.in
+++ b/gram/client_tools/test/globus-gram-client-tools-local-test.pl.in
@@ -10,7 +10,7 @@ use warnings;
 use strict;
 use Globus::Testing::Utilities;
 use Globus::Core::Paths;
-use POSIX;
+use File::Temp qw/:POSIX/;
 use IO::File;
 
 my $u = new Globus::Testing::Utilities(); 
@@ -30,7 +30,7 @@ sub test_gram_local
     my $rc = 0;
     my $rcx = 0;
     my $year = (localtime)[5] + 1900;
-    my $tmpfile = POSIX::tmpnam();
+    my $tmpfile = File::Temp::tmpnam();
     my $personal_gatekeeper = $Globus::Core::Paths::bindir
             . '/globus-personal-gatekeeper';
     my $arg_file;

--- a/gridftp/client/source/test/FtpTestLib.pm
+++ b/gridftp/client/source/test/FtpTestLib.pm
@@ -36,7 +36,8 @@ require Exporter;
 
 use strict;
 
-use POSIX ();
+use POSIX;
+use File::Temp qw/:POSIX/;
 use Carp;
 use Sys::Hostname;
 use Data::Dumper;
@@ -190,7 +191,7 @@ sub compare_local_files($$)
 {
     my($a,$b) = @_;
     my $diffs;
-    my $tmpfile = POSIX::tmpnam();
+    my $tmpfile = File::Temp::tmpnam();
     my $script =
         'binmode(STDOUT); binmode(STDIN);' .
         'while(<>) { s/\[restart plugin\].*?\n//g; print; }';
@@ -312,7 +313,7 @@ sub setup_remote_dest()
     my $dest_file;
     
     $dest_host = ($ENV{FTP_TEST_DEST_HOST} or 'localhost');
-    $dest_file = ($ENV{FTP_TEST_DEST_FILE} or POSIX::tmpnam());
+    $dest_file = ($ENV{FTP_TEST_DEST_FILE} or File::Temp::tmpnam());
 
     return ($dest_host, $dest_file);
 }
@@ -369,7 +370,7 @@ sub get_remote_file($$;$)
     my $host = shift;
     my $file = shift;
     my $user = shift;
-    my $dest = POSIX::tmpnam();
+    my $dest = File::Temp::tmpnam();
     
     push(@{$self->{staged_files}}, $dest);
     

--- a/gridftp/client/source/test/bad-buffer-test.pl
+++ b/gridftp/client/source/test/bad-buffer-test.pl
@@ -20,7 +20,6 @@
 # Try reading an url by passing in a bad data buffer
 
 use strict;
-use POSIX;
 use Test::More;
 use File::Basename;
 use lib dirname($0);

--- a/gridftp/client/source/test/caching-extended-get-test.pl
+++ b/gridftp/client/source/test/caching-extended-get-test.pl
@@ -22,7 +22,7 @@
 #
 
 use strict;
-use POSIX;
+use File::Temp qw/:POSIX/;
 use Test::More;
 use File::Basename;
 use lib dirname($0);
@@ -52,7 +52,7 @@ my @test_parallelism = (1, 3, 10);
 sub basic_func
 {
     my ($parallelism) = (shift);
-    my $tmpname = POSIX::tmpnam();
+    my $tmpname = File::Temp::tmpnam();
     my ($errors,$rc) = ("",0);
 
     unlink($tmpname);
@@ -116,7 +116,7 @@ for(my $i = 1; $i <= 43; $i++)
 # and no core file is generated.
 sub restart_test
 {
-    my $tmpname = POSIX::tmpnam();
+    my $tmpname = File::Temp::tmpnam();
     my ($errors,$rc) = ("",0);
     my ($restart_point) = shift;
     my ($par) = shift;
@@ -151,7 +151,7 @@ Do an extended get of $testfile, enabling perf_plugin
 =cut
 sub perf_test
 {
-    my $tmpname = POSIX::tmpnam();
+    my $tmpname = File::Temp::tmpnam();
     my ($errors,$rc) = ("",0);
 
     my $command = "$test_exec -s $proto$source_host$testfile -M";
@@ -172,7 +172,7 @@ Do an extended get of $testfile, enabling throughput_plugin
 =cut
 sub throughput_test
 {
-    my $tmpname = POSIX::tmpnam();
+    my $tmpname = File::Temp::tmpnam();
     my ($errors,$rc) = ("",0);
 
     my $command = "$test_exec -s $proto$source_host$testfile -T";

--- a/gridftp/client/source/test/caching-get-test.pl
+++ b/gridftp/client/source/test/caching-get-test.pl
@@ -21,7 +21,7 @@
 #
 
 use strict;
-use POSIX;
+use File::Temp qw/:POSIX/;
 use File::Basename;
 use lib dirname($0);
 use Test::More;
@@ -45,7 +45,7 @@ my ($source_host, $source_file, $local_copy) = setup_remote_source();
 sub basic_func
 {
     my ($use_proxy) = (shift);
-    my $tmpname = POSIX::tmpnam();
+    my $tmpname = File::Temp::tmpnam();
     my ($errors,$rc) = ("",0);
 
     if($use_proxy == 0)
@@ -57,7 +57,7 @@ sub basic_func
     $errors = run_command($command, $use_proxy ? 0 : -1, $tmpname);
     if($errors eq "" && $use_proxy)
     {
-        my ($newtmp)=(POSIX::tmpnam());
+        my $newtmp = File::Temp::tmpnam();
 	system("cat \"$local_copy\" \"$local_copy\" > $newtmp");
 
 	$errors .= compare_local_files($newtmp, $tmpname);
@@ -119,7 +119,7 @@ for(my $i = 1; $i <= 43; $i++)
 # and no core file is generated.
 sub restart_test
 {
-    my $tmpname = POSIX::tmpnam();
+    my $tmpname = File::Temp::tmpnam();
     my ($errors,$rc) = ("",0);
     my ($restart_point) = shift;
 
@@ -129,7 +129,7 @@ sub restart_test
     $errors = run_command($command, 0, $tmpname);
     if($errors eq "")
     {
-        my ($newtmp)=(POSIX::tmpnam());
+        my $newtmp = File::Temp::tmpnam();
         system("cat \"$local_copy\" \"$local_copy\" > $newtmp");
 
         $errors .= compare_local_files($newtmp, $tmpname);

--- a/gridftp/client/source/test/caching-transfer-test.pl
+++ b/gridftp/client/source/test/caching-transfer-test.pl
@@ -22,7 +22,6 @@
 #
 
 use strict;
-use POSIX;
 use Test::More;
 use File::Basename;
 use lib dirname($0);

--- a/gridftp/client/source/test/exist-test.pl
+++ b/gridftp/client/source/test/exist-test.pl
@@ -24,7 +24,7 @@
 =cut
 
 use strict;
-use POSIX;
+use File::Temp qw/:POSIX/;
 use Test::More;
 use File::Basename;
 use lib dirname($0);
@@ -53,7 +53,7 @@ if(source_is_remote())
 }
 else
 {
-    my $emptydir = POSIX::tmpnam();
+    my $emptydir = File::Temp::tmpnam();
     my @test_dirs;
 
     if(!defined($ENV{'FTP_TEST_BACKEND'}))

--- a/gridftp/client/source/test/extended-get-test.pl
+++ b/gridftp/client/source/test/extended-get-test.pl
@@ -22,7 +22,7 @@
 #
 
 use strict;
-use POSIX;
+use File::Temp qw/:POSIX/;
 use Test::More;
 use File::Basename;
 use lib dirname($0);
@@ -53,7 +53,7 @@ my @test_parallelism = (1,3,10);
 sub basic_func
 {
     my ($parallelism) = (shift);
-    my $tmpname = POSIX::tmpnam();
+    my $tmpname = File::Temp::tmpnam();
     my ($errors,$rc) = ("",0);
 
     unlink($tmpname);
@@ -117,7 +117,7 @@ for(my $i = 1; $i <= 43; $i++)
 # and no core file is generated.
 sub restart_test
 {
-    my $tmpname = POSIX::tmpnam();
+    my $tmpname = File::Temp::tmpnam();
     my ($errors,$rc) = ("",0);
     my ($restart_point) = shift;
     my ($par) = shift;
@@ -152,7 +152,7 @@ Do an extended get of $testfile, enabling perf_plugin
 =cut
 sub perf_test
 {
-    my $tmpname = POSIX::tmpnam();
+    my $tmpname = File::Temp::tmpnam();
     my ($errors,$rc) = ("",0);
 
     my $command = "$test_exec -s $proto$source_host$testfile -M";
@@ -172,7 +172,7 @@ Do an extended get of $testfile, enabling throughput_plugin
 =cut
 sub throughput_test
 {
-    my $tmpname = POSIX::tmpnam();
+    my $tmpname = File::Temp::tmpnam();
     my ($errors,$rc) = ("",0);
 
     my $command = "$test_exec -s $proto$source_host$testfile -T";

--- a/gridftp/client/source/test/get-test.pl
+++ b/gridftp/client/source/test/get-test.pl
@@ -23,7 +23,7 @@ Tests to exercise the "get" functionality of the Globus FTP client library.
 
 =cut
 use strict;
-use POSIX;
+use File::Temp qw/:POSIX/;
 use Test::More;
 use File::Basename;
 use lib dirname($0);
@@ -60,7 +60,7 @@ files compare.
 sub basic_func
 {
     my ($use_proxy) = (shift);
-    my $tmpname = POSIX::tmpnam();
+    my $tmpname = File::Temp::tmpnam();
     my ($errors,$rc) = ("",0);
 
     if($use_proxy == 0)
@@ -147,7 +147,7 @@ program returns 0, files compare, and no core file is generated.
 =cut
 sub restart_test
 {
-    my $tmpname = POSIX::tmpnam();
+    my $tmpname = File::Temp::tmpnam();
     my ($errors,$rc) = ("",0);
     my ($restart_point) = shift;
 
@@ -196,7 +196,7 @@ DCAU with subject authorization with an invalid subject.
 =cut
 sub dcau_test
 {
-    my $tmpname = POSIX::tmpnam();
+    my $tmpname = File::Temp::tmpnam();
     my ($errors,$rc) = ("",0);
     my ($dcau, $desired_rc) = @_;
 
@@ -254,7 +254,7 @@ PROT with private protection
 =cut
 sub prot_test
 {
-    my $tmpname = POSIX::tmpnam();
+    my $tmpname = File::Temp::tmpnam();
     my ($errors,$rc) = ("",0);
     my ($prot, $desired_rc) = @_;
 
@@ -283,7 +283,7 @@ Do a simple get of $test_url, enabling perf_plugin
 =cut
 sub perf_test
 {
-    my $tmpname = POSIX::tmpnam();
+    my $tmpname = File::Temp::tmpnam();
     my ($errors,$rc) = ("",0);
 
     my $command = "$test_exec -M -s '$proto$source_host$source_file'";
@@ -309,7 +309,7 @@ Do a simple get of $test_url, enabling throughput_plugin
 =cut
 sub throughput_test
 {
-    my $tmpname = POSIX::tmpnam();
+    my $tmpname = File::Temp::tmpnam();
     my ($errors,$rc) = ("",0);
 
     my $command = "$test_exec -T -s '$proto$source_host$source_file'";
@@ -336,7 +336,7 @@ the default restart plugin to cope with them.
 =cut
 sub restart_plugin_test
 {
-    my $tmpname = POSIX::tmpnam();
+    my $tmpname = File::Temp::tmpnam();
     my ($errors,$rc) = ("",0);
     my $other_args;
 

--- a/gridftp/client/source/test/multiple-block-get-test.pl
+++ b/gridftp/client/source/test/multiple-block-get-test.pl
@@ -22,7 +22,7 @@
 #
 
 use strict;
-use POSIX;
+use File::Temp qw/:POSIX/;
 use Test::More;
 use File::Basename;
 use lib dirname($0);
@@ -44,7 +44,7 @@ my ($source_host, $source_file, $local_copy) = setup_remote_source();
 sub basic_func
 {
     my ($use_proxy) = (shift);
-    my $tmpname = POSIX::tmpnam();
+    my $tmpname = File::Temp::tmpnam();
     my ($errors,$rc) = ("",0);
     my ($old_proxy);
 
@@ -111,7 +111,7 @@ for(my $i = 1; $i <= 43; $i++)
 # and no core file is generated.
 sub restart_test
 {
-    my $tmpname = POSIX::tmpnam();
+    my $tmpname = File::Temp::tmpnam();
     my ($errors,$rc) = ("",0);
     my ($restart_point) = shift;
 

--- a/gridftp/client/source/test/partial-get-test.pl
+++ b/gridftp/client/source/test/partial-get-test.pl
@@ -22,7 +22,7 @@
 #
 
 use strict;
-use POSIX;
+use File::Temp qw/:POSIX/;
 use Test::More;
 use FileHandle;
 use File::Basename;
@@ -54,7 +54,7 @@ close($fh);
 sub basic_func
 {
     my ($use_proxy) = (shift);
-    my $tmpname = POSIX::tmpnam();
+    my $tmpname = File::Temp::tmpnam();
     my ($errors,$rc) = ("",0);
 
     unlink($tmpname);
@@ -102,7 +102,7 @@ for(my $i = 1; $i <= 43; $i++)
 # and no core file is generated.
 sub restart_test
 {
-    my $tmpname = POSIX::tmpnam();
+    my $tmpname = File::Temp::tmpnam();
     my ($errors,$rc) = ("",0);
     my ($restart_point) = shift;
 

--- a/gridftp/client/source/test/partial-put-test.pl
+++ b/gridftp/client/source/test/partial-put-test.pl
@@ -22,7 +22,6 @@
 #
 
 use strict;
-use POSIX;
 use Test::More;
 use FileHandle;
 use File::Basename;

--- a/gridftp/client/source/test/partial-transfer-test.pl
+++ b/gridftp/client/source/test/partial-transfer-test.pl
@@ -22,7 +22,7 @@
 #
 
 use strict;
-use POSIX;
+use File::Temp qw/:POSIX/;
 use Test::More;
 use FileHandle;
 use File::Basename;
@@ -47,8 +47,8 @@ my ($dest_host, $dest_file) = setup_remote_dest();
 # is generated.
 sub basic_func
 {
-    my $tmpname = POSIX::tmpnam();
-    my $tmpname2 = POSIX::tmpnam();
+    my $tmpname = File::Temp::tmpnam();
+    my $tmpname2 = File::Temp::tmpnam();
     my ($errors,$rc) = ("",0);
     my $newfile = new FileHandle;
     my $offset = shift;

--- a/gridftp/client/source/test/size-test.pl
+++ b/gridftp/client/source/test/size-test.pl
@@ -24,7 +24,6 @@ Tests to exercise the size checking of the client library.
 =cut
 
 use strict;
-use POSIX;
 use Test::More;
 use File::Basename;
 use lib dirname($0);

--- a/gridftp/client/source/test/user-auth-test.pl
+++ b/gridftp/client/source/test/user-auth-test.pl
@@ -22,7 +22,7 @@
 #
 
 use strict;
-use POSIX;
+use File::Temp qw/:POSIX/;
 use Test::More;
 use File::Basename;
 use lib dirname($0);
@@ -40,7 +40,7 @@ my ($source_host, $source_file, $local_copy) = setup_remote_source();
 # and no core file is generated, or no valid proxy, and program returns 1.
 sub correct_auth
 {
-    my $tmpname = POSIX::tmpnam();
+    my $tmpname = File::Temp::tmpnam();
     my ($errors,$rc) = ("",0);
     my ($hostname) = ();
     unlink($tmpname);
@@ -82,7 +82,7 @@ push(@tests, "correct_auth");
 # Success if program returns 1 and no core file is generated.
 sub incorrect_auth
 {
-    my $tmpname = POSIX::tmpnam();
+    my $tmpname = File::Temp::tmpnam();
     my ($errors,$rc) = ("",0);
     my ($hostname) = ("googly_goodness");
     unlink($tmpname);


### PR DESCRIPTION
```
Started server at port 34695
Unimplemented: POSIX::tmpnam(): use File::Temp instead at FtpTestLib.pm line 372.
Test exited with 65280
```
