### PR TITLE
Put back use of SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS

### DIFF
--- a/gsi/gssapi/source/library/globus_i_gsi_gss_utils.c
+++ b/gsi/gssapi/source/library/globus_i_gsi_gss_utils.c
@@ -471,8 +471,8 @@ globus_i_gsi_gss_create_and_fill_context(
         goto free_cert_dir;
     }
 
-    /* No longer setting SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS since it seemed
-     * like a stop-gap measure to interoperate with broken SSL */
+    /* This is needed for compatibility with Bestman */
+    SSL_set_options(context->gss_ssl, SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS);
 
     local_result = globus_gsi_callback_get_SSL_callback_data_index(&cb_index);
     if(local_result != GLOBUS_SUCCESS)


### PR DESCRIPTION
With the update of globus-gssapi-gsi to version 2.15, the option SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS is no longer used.

Users of the Globus Toolkit report that this breaks interaction with Bestman.

See https://its.cern.ch/jira/browse/DMC-974 and the comments to the EPEL update ticket https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2017-b1d8b4aed9 for details.

This pull request puts the use of the option back to restore the lost functionality.
