### PR TITLE
Fix regex for perl 5.26 compatibility

### DIFF
--- a/common/source/scripts/Paths.pm.in
+++ b/common/source/scripts/Paths.pm.in
@@ -37,7 +37,7 @@ sub eval_path
         my $evaluated;
         eval "\$evaluated = \${$1}";
 
-        $path =~ s/\${$varname}/$evaluated/g;
+        $path =~ s/\$\{$varname\}/$evaluated/g;
         if ($path eq $last)
         {
             die "Error evaluating $last\n";

--- a/gram/jobmanager/scripts/JobDescription.pm
+++ b/gram/jobmanager/scripts/JobDescription.pm
@@ -109,7 +109,7 @@ sub new
                 my $arrayref = $self->{$key};
 
                 for ($i = 0; $i < scalar(@{$arrayref}); $i++) {
-                    $arrayref->[$i] =~ s/\${GLOBUS_USER_HOME}/$home/g;
+                    $arrayref->[$i] =~ s/\$\{GLOBUS_USER_HOME\}/$home/g;
                 }
             }
         }
@@ -130,7 +130,7 @@ sub new
                 my $arrayref = $self->{$key};
 
                 for ($i = 0; $i < scalar(@{$arrayref}); $i++) {
-                    $arrayref->[$i] =~ s/\${GLOBUS_LOCATION}/$home/g;
+                    $arrayref->[$i] =~ s/\$\{GLOBUS_LOCATION\}/$home/g;
                 }
             }
         }


### PR DESCRIPTION
Fixes errors: "Unescaped left brace in regex is illegal here in regex"

