### PR TITLE
Fix dependency

### DIFF
--- a/gsi/gss_assist/source/configure.ac
+++ b/gsi/gss_assist/source/configure.ac
@@ -5,7 +5,7 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])
 AC_SUBST([AGE_VERSION], [8])
-AC_SUBST([PACKAGE_DEPS], ["globus-common >= 14, globus-gsi-sysconfig >= 6, globus-gsi-cert-utils >= 8, globus-gssapi-gsi >= 13, globus-callout >= 2, globus-gsi-credential >= 6"])
+AC_SUBST([PACKAGE_DEPS], ["globus-common >= 14, globus-gsi-sysconfig >= 7, globus-gsi-cert-utils >= 8, globus-gssapi-gsi >= 13, globus-callout >= 2, globus-gsi-credential >= 6"])
 
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([1.11 foreign parallel-tests tar-pax])


### PR DESCRIPTION
globus-gss-assist requires globus-gsi-sysconfig >= 7.

When trying to compile using version 6 it fails:
```
.libs/libglobus_gss_assist_la-read_vhost_cred_dir.o: In function `globus_gss_assist_read_vhost_cred_dir':
/builddir/build/BUILD/globus_gss_assist-11.0/read_vhost_cred_dir.c:76: undefined reference to `GLOBUS_GSI_SYSCONFIG_GET_VHOST_CRED_DIR'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:548: libglobus_gss_assist.la] Error 1
make[1]: Leaving directory '/builddir/build/BUILD/globus_gss_assist-11.0'
make: *** [Makefile:777: all-recursive] Error 1
```