### PR TITLE
Fix race condition

### DIFF
--- a/gsi/gss_assist/source/test/Makefile.am
+++ b/gsi/gss_assist/source/test/Makefile.am
@@ -77,14 +77,18 @@ TESTS_ENVIRONMENT = export \
 	echo 01 > $@
 
 # Test Cert/Key
-testcred.key testcred1.key testcred2.key: testcred.srl
+testcred.key testcred1.key testcred2.key:
 	umask 077; $(OPENSSL) genrsa -out $@ 1024
+
 .key.req:
 	$(OPENSSL) req -subj "/CN=$*" -new -key $< -out $@ -config testcred.cnf
 
 .req.cert:
 	umask 022; $(OPENSSL) x509 -passin pass:globus -req -days 365 -in $*.req -CA testcred.cacert -CAkey testcred.cakey -out $@
 
+testcred.cert: testcred.srl
+testcred1.cert: testcred.cert
+testcred2.cert: testcred1.cert
 
 CLEANFILES = \
 	testcred.key testcred.cert testcred.req \

--- a/gsi/gssapi/source/test/Makefile.am
+++ b/gsi/gssapi/source/test/Makefile.am
@@ -181,7 +181,6 @@ testcred.cacert: testcred.cnf
         echo "$$linkname" > $@
 
 .link.signing_policy:
-	echo 01 > $*.srl
 	linkname=`cat $<`; \
 	policyfile=$${linkname%.0}.signing_policy; \
 	echo "access_id_CA      X509         '/CN=ca'" > $${policyfile}; \
@@ -196,19 +195,25 @@ testcred.cacert: testcred.cnf
 testcred.key testcred-nocn.key testcred-dns1.key testcred-dns2.key:
 	umask 077; $(OPENSSL) genrsa 1024 > $@
 
-testcred-nocn.req: testcred-nocn.key testcred.signing_policy
-	$(OPENSSL) req -subj "/userId=test" -new -config testcred.cnf -key $< > $@
-
-testcred.req: testcred.key testcred.signing_policy
+testcred.req: testcred.key
 	$(OPENSSL) req -subj "/CN=test" -new -config testcred.cnf -key $< > $@
 
-testcred-dns1.req: testcred-dns1.key testcred.signing_policy
+testcred-nocn.req: testcred-nocn.key
+	$(OPENSSL) req -subj "/userId=test" -new -config testcred.cnf -key $< > $@
+
+testcred-dns1.req: testcred-dns1.key
 	$(OPENSSL) req -subj "/CN=dns1" -reqexts testcred-dns1 -new -config testcred.cnf -key $< > $@
-testcred-dns2.req: testcred-dns2.key testcred.signing_policy
+
+testcred-dns2.req: testcred-dns2.key
 	$(OPENSSL) req -subj "/CN=dns2" -reqexts testcred-dns2 -new -config testcred.cnf -key $< > $@
 
 .req.cert:
 	umask 022; $(OPENSSL) x509 -extensions $* -extfile testcred.cnf -req -passin pass:globus -days 365 -CAkey testcred.cakey -CA testcred.cacert -in $< > $@
+
+testcred.cert: testcred.srl
+testcred-nocn.cert: testcred.cert
+testcred-dns1.cert: testcred-nocn.cert
+testcred-dns2.cert: testcred-dns1.cert
 endif
 
 EXTRA_DIST = \


### PR DESCRIPTION
The "make check" for globus-gssapi-gsi and globus-gss-assist fail when using parallel make due to a race condition.

The problem is that several processes are running simultaneously that try to modify the testcred.srl file, this results in a high probability that one of them fails with the error:

"unable to load number from testcred.srl"

This PR adds a set of dependencies beteen the targets that modify testcred.srl so that they are executed sequentially.
