### PR TITLE
Terminate the connection if gridftp server fails to write the 220 banner

### DIFF
--- a/gridftp/server-lib/src/globus_gridftp_server_control.c
+++ b/gridftp/server-lib/src/globus_gridftp_server_control.c
@@ -1343,7 +1343,7 @@ globus_l_gsc_220_write_cb(
 err:
 
     globus_xio_attr_init(&close_attr);
-    globus_l_gsc_server_ref_check(server_handle);
+    globus_l_gsc_terminate(server_handle);
     globus_mutex_unlock(&server_handle->mutex);
 
     GlobusGridFTPServerDebugInternalExitWithError();


### PR DESCRIPTION
If the client opens a connection and immediately closes it before the gridftp server can write the "220 ... ready." banner, the server process gets gets stuck in globus_cond_wait() in globus_gridftp_server.c.

Following through the code:

1. --Client connects to server--
2. globus_l_gsc_open_cb() registers a write for the FTP banner and sets callback globus_l_gsc_220_write_cb()
3. --Client disconnects before banner is sent--
4. globus_l_gsc_220_write_cb() detects failure when checking result variable
5. The connection never closes, and the server gets stuck in globus_cond_wait()

I suspect that the write error lead to callbacks not being registered as expected, so nothing properly signals globus_l_gfs_cond. For the fix, it seems reasonable that the server should end the connection if there's an error sending the FTP banner.

This problem showed up for us with a load balanced (LVS) set of GridFTP servers. The TCP health check from keepalived triggered the bug. Here is a short python program to reproduce the problem.

```python
#!/usr/bin/env python
import socket, struct

host = 'gridftp.example.edu'
port = 2811

# Open a connection and immediately close with a reset
s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
s.connect((host, port))
l_onoff = 1
l_linger = 0
s.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER,
             struct.pack('ii', l_onoff, l_linger))
s.close()
```