### PR TITLE
2048 bits

### DIFF
--- a/gass/copy/source/test/Makefile.am
+++ b/gass/copy/source/test/Makefile.am
@@ -49,7 +49,7 @@ check_DATA =  \
 
 # Test Cert/Key
 .srl.key:
-	umask 077; $(OPENSSL) genrsa -out $@ 1024
+	umask 077; $(OPENSSL) genrsa -out $@ 2048
 .key.req:
 	$(OPENSSL) req -subj "/CN=test" -new -key $< -out $@ -config $*.cnf
 

--- a/gram/client/source/test/Makefile.am
+++ b/gram/client/source/test/Makefile.am
@@ -63,7 +63,7 @@ LOG_COMPILER = $(LIBTOOL) --mode=execute $(GLOBUS_XIO_GSI_DLOPEN)
 
 # Test Cert/Key
 .srl.key:
-	umask 077; $(OPENSSL) genrsa -out $@ 1024
+	umask 077; $(OPENSSL) genrsa -out $@ 2048
 .key.req:
 	$(OPENSSL) req -subj "/CN=test" -new -key $< -out $@ -config $*.cnf
 

--- a/gram/jobmanager/source/test/Makefile.am
+++ b/gram/jobmanager/source/test/Makefile.am
@@ -35,7 +35,7 @@ check_DATA = \
 
 # Test Cert/Key
 .srl.key:
-	umask 077; $(OPENSSL) genrsa -out $@ 1024
+	umask 077; $(OPENSSL) genrsa -out $@ 2048
 .key.req:
 	$(OPENSSL) req -subj "/CN=test" -new -key $< -out $@ -config $*.cnf
 

--- a/gram/protocol/source/test/Makefile.am
+++ b/gram/protocol/source/test/Makefile.am
@@ -68,7 +68,7 @@ LOG_COMPILER = $(LIBTOOL) --mode=execute $(GSI_DRIVER_LIBS) \
 
 # Test Cert/Key
 .srl.key:
-	umask 077; $(OPENSSL) genrsa -out $@ 1024
+	umask 077; $(OPENSSL) genrsa -out $@ 2048
 .key.req:
 	$(OPENSSL) req -subj "/CN=test" -new -key $< -out $@ -config $*.cnf
 

--- a/gridftp/client/source/test/Makefile.am
+++ b/gridftp/client/source/test/Makefile.am
@@ -164,7 +164,7 @@ LOG_COMPILER = $(LIBTOOL) --mode=execute \
 
 # Test Cert/Key
 .srl.key:
-	umask 077; $(OPENSSL) genrsa -out $@ 1024
+	umask 077; $(OPENSSL) genrsa -out $@ 2048
 .key.req:
 	$(OPENSSL) req -subj "/CN=test" -new -key $< -out $@ -config $*.cnf
 

--- a/gridftp/control/source/test/Makefile.am
+++ b/gridftp/control/source/test/Makefile.am
@@ -105,7 +105,7 @@ LOG_COMPILER = $(LIBTOOL) --mode=execute $(GSI_DRIVER_DLOPEN)
 
 # Test Cert/Key
 .srl.key:
-	umask 077; $(OPENSSL) genrsa -out $@ 1024
+	umask 077; $(OPENSSL) genrsa -out $@ 2048
 .key.req:
 	$(OPENSSL) req -subj "/CN=test" -new -key $< -out $@ -config $*.cnf
 

--- a/gridftp/gridftp_driver/source/test/Makefile.am
+++ b/gridftp/gridftp_driver/source/test/Makefile.am
@@ -53,7 +53,7 @@ LOG_COMPILER = $(LIBTOOL) --mode=execute \
 
 # Test Cert/Key
 .srl.key:
-	umask 077; $(OPENSSL) genrsa -out $@ 1024
+	umask 077; $(OPENSSL) genrsa -out $@ 2048
 .key.req:
 	$(OPENSSL) req -subj "/CN=test" -new -key $< -out $@ -config $*.cnf
 

--- a/gridftp/server/src/test/Makefile.am
+++ b/gridftp/server/src/test/Makefile.am
@@ -62,7 +62,7 @@ AM_LDFLAGS = -dlpreopen force
 
 # Test Cert/Key
 .srl.key:
-	umask 077; $(OPENSSL) genrsa -out $@ 1024
+	umask 077; $(OPENSSL) genrsa -out $@ 2048
 .key.req:
 	$(OPENSSL) req -subj "/CN=test" -new -key $< -out $@ -config $*.cnf
 

--- a/gsi/authz/source/test/Makefile.am
+++ b/gsi/authz/source/test/Makefile.am
@@ -69,7 +69,7 @@ TESTS_ENVIRONMENT = export \
 
 # Test Cert/Key
 .srl.key:
-	umask 077; $(OPENSSL) genrsa -out $@ 1024
+	umask 077; $(OPENSSL) genrsa -out $@ 2048
 .key.req:
 	$(OPENSSL) req -subj "/CN=test" -new -key $< -out $@ -config $*.cnf
 

--- a/gsi/gss_assist/source/test/Makefile.am
+++ b/gsi/gss_assist/source/test/Makefile.am
@@ -78,7 +78,7 @@ TESTS_ENVIRONMENT = export \
 
 # Test Cert/Key
 testcred.key testcred1.key testcred2.key:
-	umask 077; $(OPENSSL) genrsa -out $@ 1024
+	umask 077; $(OPENSSL) genrsa -out $@ 2048
 
 .key.req:
 	$(OPENSSL) req -subj "/CN=$*" -new -key $< -out $@ -config testcred.cnf

--- a/gsi/gssapi/source/test/Makefile.am
+++ b/gsi/gssapi/source/test/Makefile.am
@@ -197,22 +197,22 @@ testcred.cacert: testcred.cnf
 	echo 01 > $@
 
 testcred.key testcred-nocn.key testcred-dns1.key testcred-dns2.key:
-	umask 077; $(OPENSSL) genrsa 1024 > $@
+	umask 077; $(OPENSSL) genrsa -out $@ 2048
 
 testcred.req: testcred.key
-	$(OPENSSL) req -subj "/CN=test" -new -config testcred.cnf -key $< > $@
+	$(OPENSSL) req -subj "/CN=test" -new -key $< -out $@ -config testcred.cnf
 
 testcred-nocn.req: testcred-nocn.key
-	$(OPENSSL) req -subj "/userId=test" -new -config testcred.cnf -key $< > $@
+	$(OPENSSL) req -subj "/userId=test" -new -key $< -out $@ -config testcred.cnf
 
 testcred-dns1.req: testcred-dns1.key
-	$(OPENSSL) req -subj "/CN=dns1" -reqexts testcred-dns1 -new -config testcred.cnf -key $< > $@
+	$(OPENSSL) req -subj "/CN=dns1" -reqexts testcred-dns1 -new -key $< -out $@ -config testcred.cnf
 
 testcred-dns2.req: testcred-dns2.key
-	$(OPENSSL) req -subj "/CN=dns2" -reqexts testcred-dns2 -new -config testcred.cnf -key $< > $@
+	$(OPENSSL) req -subj "/CN=dns2" -reqexts testcred-dns2 -new -key $< -out $@ -config testcred.cnf
 
 .req.cert:
-	umask 022; $(OPENSSL) x509 -extensions $* -extfile testcred.cnf -req -passin pass:globus -days 365 -CAkey testcred.cakey -CA testcred.cacert -in $< > $@
+	umask 022; $(OPENSSL) x509 -extensions $* -extfile testcred.cnf -req -passin pass:globus -days 365 -CAkey testcred.cakey -CA testcred.cacert -in $< -out $@
 
 testcred.cert: testcred.srl
 testcred-nocn.cert: testcred.cert

--- a/gsi/proxy/proxy_core/source/library/globus_gsi_proxy_handle_attrs.c
+++ b/gsi/proxy/proxy_core/source/library/globus_gsi_proxy_handle_attrs.c
@@ -24,7 +24,7 @@
 #include "globus_i_gsi_proxy.h"
 #include <errno.h>
 
-#define DEFAULT_KEY_BITS                1024
+#define DEFAULT_KEY_BITS                2048
 #define DEFAULT_PUB_EXPONENT            RSA_F4  /* 65537 */
 #define DEFAULT_SIGNING_ALGORITHM       NULL
 #define DEFAULT_CLOCK_SKEW              (5*60)    /* actually in seconds */

--- a/gsi/proxy/proxy_utils/source/programs/grid-proxy-init.1
+++ b/gsi/proxy/proxy_utils/source/programs/grid-proxy-init.1
@@ -36,7 +36,7 @@ grid-proxy-init \- Generate a new proxy certificate
 \fBgrid\-proxy\-init\fR [OPTIONS]
 .SH "DESCRIPTION"
 .sp
-The \fBgrid\-proxy\-init\fR program generates X\&.509 proxy certificates derived from the currently available certificate files\&. By default, this command generates a <ulink url="http://www\&.ietf\&.org/rfc/rfc3820\&.txt">RFC 3820</ulink> Proxy Certificate with a 1024 bit key, valid for 12 hours, in a file named /tmp/x509up_u\(cqUID\*(Aq\&. Command\-line options and environment variables can modify the format, strength, lifetime, and location of the generated proxy certificate\&.
+The \fBgrid\-proxy\-init\fR program generates X\&.509 proxy certificates derived from the currently available certificate files\&. By default, this command generates a <ulink url="http://www\&.ietf\&.org/rfc/rfc3820\&.txt">RFC 3820</ulink> Proxy Certificate with a 2048 bit key, valid for 12 hours, in a file named /tmp/x509up_u\(cqUID\*(Aq\&. Command\-line options and environment variables can modify the format, strength, lifetime, and location of the generated proxy certificate\&.
 .sp
 X\&.509 proxy certificates are short\-lived certificates, signed usually by a user\(cqs identity certificate or another proxy certificate\&. The key associated with a proxy certificate is unencrypted, so applications can authenticate using a proxy identity without providing a pass phrase\&.
 .sp
@@ -115,7 +115,7 @@ instead of the default path of
 .RS 4
 When creating the proxy certificate, use a
 \fIBITS\fR
-bit key instead of the default 1024\-bit keys\&.
+bit key instead of the default 2048\-bit keys\&.
 .RE
 .PP
 \fB\-policy \fR\fB\fIPOLICYFILE\fR\fR

--- a/gsi/proxy/proxy_utils/source/programs/grid-proxy-init.txt
+++ b/gsi/proxy/proxy_utils/source/programs/grid-proxy-init.txt
@@ -23,7 +23,7 @@ DESCRIPTION
 The *grid-proxy-init* program generates X.509 proxy certificates derived from
 the currently available certificate files.  By default, this command generates
 a <ulink url="http://www.ietf.org/rfc/rfc3820.txt">RFC 3820</ulink> Proxy
-Certificate with a 1024 bit key, valid for 12 hours, in a file named
+Certificate with a 2048 bit key, valid for 12 hours, in a file named
 +/tmp/x509up_u'UID'+.  Command-line options and environment variables can
 modify the format, strength, lifetime, and location of the generated proxy
 certificate.
@@ -81,7 +81,7 @@ The full set of command-line options to *grid-proxy-init* are:
     default path of +/tmp/x509up_u'UID'+.
 *-bits 'BITS'*::
     When creating the proxy certificate, use a 'BITS' bit key instead of the
-    default 1024-bit keys.
+    default 2048-bit keys.
 *-policy 'POLICYFILE'*::
     Add the certificate policy data described in 'POLICYFILE' as the
     ProxyCertInfo X.509 extension to the generated proxy

--- a/gsi/proxy/proxy_utils/source/programs/grid_proxy_init.c
+++ b/gsi/proxy/proxy_utils/source/programs/grid_proxy_init.c
@@ -145,8 +145,8 @@ main(
     char **                             argv)
 {
     globus_result_t                     result  = GLOBUS_SUCCESS;
-    /* default proxy to 1024 bits */
-    int                                 key_bits    = 1024;
+    /* default proxy to 2048 bits */
+    int                                 key_bits    = 2048;
     /* default to a 12 hour cert */
     int                                 valid       = 12*60;
     int                                 verify      = 0;

--- a/gsi/proxy/proxy_utils/source/test/Makefile.am
+++ b/gsi/proxy/proxy_utils/source/test/Makefile.am
@@ -50,7 +50,7 @@ TESTS_ENVIRONMENT = \
 
 # Test Cert/Key
 .srl.key:
-	umask 077; $(OPENSSL) genrsa -out $@ 1024
+	umask 077; $(OPENSSL) genrsa -out $@ 2048
 .key.req:
 	$(OPENSSL) req -subj "/CN=test" -new -key $< -out $@ -config $*.cnf
 

--- a/io/compat/test/Makefile.am
+++ b/io/compat/test/Makefile.am
@@ -55,7 +55,7 @@ if ENABLE_TESTS
 
 # Test Cert/Key
 .srl.key:
-	umask 077; $(OPENSSL) genrsa -out $@ 1024
+	umask 077; $(OPENSSL) genrsa -out $@ 2048
 .key.req:
 	$(OPENSSL) req -subj "/CN=test" -new -key $< -out $@ -config $*.cnf
 

--- a/myproxy/source/myproxy-test
+++ b/myproxy/source/myproxy-test
@@ -84,14 +84,17 @@ default_ca      = CA_default            # The default ca section
 [ CA_default ]
 dir            = $privcerts              # top dir
 database       = $privcerts/index.txt        # index file.
-new_certs_dir	= $privcerts/         # new certs dir
+new_certs_dir  = $privcerts/         # new certs dir
  
 certificate    = $privcerts/cacert.pem       # The CA cert
 serial         = $privcerts/serial           # serial no file
 private_key    = $privcerts/cakey.pem # CA private key
 RANDFILE       = $privcerts/.rand    # random number file
-default_md     = sha1                   # md to use
+default_md     = default
+
 [ req ]
+default_bits   = 2048
+default_md     = sha1
 distinguished_name = req_distinguished_name
 
 [ req_distinguished_name ]


### PR DESCRIPTION
With the upcoming openssl 1.1.1 the default security level is increased from "1" to "2". This means that RSA keys must be at least 2048 bits.