### PR TITLE
Avoid TLS 1.3 for now

### DIFF
--- a/gsi/gssapi/source/library/globus_i_gsi_gss_utils.c
+++ b/gsi/gssapi/source/library/globus_i_gsi_gss_utils.c
@@ -2326,7 +2326,10 @@ globus_i_gsi_gssapi_init_ssl_context(
     if (globus_i_gsi_gssapi_min_tls_protocol == 0)
         globus_i_gsi_gssapi_min_tls_protocol = TLS1_VERSION;
     if (globus_i_gsi_gssapi_max_tls_protocol == 0)
-        globus_i_gsi_gssapi_max_tls_protocol = TLS_MAX_VERSION;
+        // The GSI GSSAPI currently does not work with TLS 1.3
+        // Use TLS1_2_VERSION instead of TLS_MAX_VERSION as the maximum TLS
+        // protocol version until it has been ported
+        globus_i_gsi_gssapi_max_tls_protocol = TLS1_2_VERSION;
     GLOBUS_I_GSI_GSSAPI_DEBUG_FPRINTF(
         3, (globus_i_gsi_gssapi_debug_fstream,
         "MIN_TLS_PROTOCOL: %x\n", globus_i_gsi_gssapi_min_tls_protocol));


### PR DESCRIPTION
This is a workaround for the issue described in #123.

This PR avoids the problems with TLS 1.3 by disallowing its use. This is not the proper fix, the code should be ported work with TLS 1.3.

Debian unstable, Fedora 29 and Fedora rawhide now all use openssl 1.1.1 which adds support for TLS 1.3. This PR allows GT to continue to work (using TLS 1.2) on these distributions. Hopefully this will be temporary, and someone who understands the gssapi gsi code and openssl better can port it properly to TLS 1.3.